### PR TITLE
Implement cart feature with filters

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -1,0 +1,35 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\CartItem;
+use App\Models\Course;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CartController extends Controller
+{
+    public function index()
+    {
+        $items = CartItem::with('course')->where('user_id', Auth::id())->get();
+        return view('front.cart', compact('items'));
+    }
+
+    public function store(Request $request, Course $course)
+    {
+        $item = CartItem::firstOrCreate([
+            'user_id' => Auth::id(),
+            'course_id' => $course->id,
+        ], [
+            'quantity' => 1,
+        ]);
+        return back()->with('success', 'Course added to cart');
+    }
+
+    public function destroy(CartItem $cartItem)
+    {
+        if ($cartItem->user_id == Auth::id()) {
+            $cartItem->delete();
+        }
+        return back();
+    }
+}

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -53,6 +53,9 @@ class CategoryController extends Controller
 
             $validated['slug'] = Str::slug($validated['name']);
 
+            $validated['course_type'] = $request->input('course_type', 'online');
+            $validated['level'] = $request->input('level', 'beginner');
+
             $category = Category::create($validated);
 
         });
@@ -94,6 +97,8 @@ class CategoryController extends Controller
             }
 
             $validated['slug'] = Str::slug($validated['name']);
+            $validated['course_type'] = $request->input('course_type', $category->course_type);
+            $validated['level'] = $request->input('level', $category->level);
 
             $category ->update($validated);
 

--- a/app/Http/Requests/StoreCategoryRequest.php
+++ b/app/Http/Requests/StoreCategoryRequest.php
@@ -22,9 +22,10 @@ class StoreCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
-                'name' => ['required', 'string', 'max:255'],
-                'icon' => ['required', 'image', 'mimes:png,jpg,jpeg'],
+            'name' => ['required', 'string', 'max:255'],
+            'icon' => ['required', 'image', 'mimes:png,jpg,jpeg'],
+            'course_type' => ['required', 'in:online,onsite'],
+            'level' => ['required', 'in:beginner,intermediate,advance'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateCategoryRequest.php
+++ b/app/Http/Requests/UpdateCategoryRequest.php
@@ -22,9 +22,10 @@ class UpdateCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
             'name' => ['required', 'string', 'max:255'],
             'icon' => ['sometimes', 'image', 'mimes:png,jpg,jpeg'],
+            'course_type' => ['required', 'in:online,onsite'],
+            'level' => ['required', 'in:beginner,intermediate,advance'],
         ];
     }
 }

--- a/app/Models/CartItem.php
+++ b/app/Models/CartItem.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CartItem extends Model
+{
+    use HasFactory;
+    protected $fillable = ['user_id','course_id','quantity'];
+
+    public function user(){
+        return $this->belongsTo(User::class);
+    }
+
+    public function course(){
+        return $this->belongsTo(Course::class);
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -13,7 +13,9 @@ class Category extends Model
         'name',
         'slug',
         'icon',
-        'email'
+        'email',
+        'course_type',
+        'level'
     ];
 
     protected $guarded =[

--- a/database/migrations/2025_08_01_000000_add_mode_and_level_to_categories_table.php
+++ b/database/migrations/2025_08_01_000000_add_mode_and_level_to_categories_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->enum('course_type', ['online', 'onsite'])->default('online');
+            $table->enum('level', ['beginner', 'intermediate', 'advance'])->default('beginner');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropColumn(['course_type', 'level']);
+        });
+    }
+};

--- a/database/migrations/2025_08_01_010000_create_cart_items_table.php
+++ b/database/migrations/2025_08_01_010000_create_cart_items_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('cart_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('course_id')->constrained()->onDelete('cascade');
+            $table->unsignedInteger('quantity')->default(1);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cart_items');
+    }
+};

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -32,6 +32,25 @@
                         <x-input-error :messages="$errors->get('icon')" class="mt-2" />
                     </div>
 
+                    <div class="mt-4">
+                        <x-input-label for="course_type" :value="__('Course Type')" />
+                        <select id="course_type" name="course_type" class="block mt-1 w-full border-gray-300 rounded">
+                            <option value="online">Online</option>
+                            <option value="onsite">Onsite</option>
+                        </select>
+                        <x-input-error :messages="$errors->get('course_type')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-input-label for="level" :value="__('Level')" />
+                        <select id="level" name="level" class="block mt-1 w-full border-gray-300 rounded">
+                            <option value="beginner">Beginner</option>
+                            <option value="intermediate">Intermediate</option>
+                            <option value="advance">Advance</option>
+                        </select>
+                        <x-input-error :messages="$errors->get('level')" class="mt-2" />
+                    </div>
+
                     <div class="flex items-center justify-end mt-4">
             
                         <button type="submit" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -34,6 +34,25 @@
                         <x-input-error :messages="$errors->get('icon')" class="mt-2" />
                     </div>
 
+                    <div class="mt-4">
+                        <x-input-label for="course_type" :value="__('Course Type')" />
+                        <select id="course_type" name="course_type" class="block mt-1 w-full border-gray-300 rounded">
+                            <option value="online" {{ $category->course_type == 'online' ? 'selected' : '' }}>Online</option>
+                            <option value="onsite" {{ $category->course_type == 'onsite' ? 'selected' : '' }}>Onsite</option>
+                        </select>
+                        <x-input-error :messages="$errors->get('course_type')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-input-label for="level" :value="__('Level')" />
+                        <select id="level" name="level" class="block mt-1 w-full border-gray-300 rounded">
+                            <option value="beginner" {{ $category->level == 'beginner' ? 'selected' : '' }}>Beginner</option>
+                            <option value="intermediate" {{ $category->level == 'intermediate' ? 'selected' : '' }}>Intermediate</option>
+                            <option value="advance" {{ $category->level == 'advance' ? 'selected' : '' }}>Advance</option>
+                        </select>
+                        <x-input-error :messages="$errors->get('level')" class="mt-2" />
+                    </div>
+
                     <div class="flex items-center justify-end mt-4">
             
                         <button type="submit" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">

--- a/resources/views/front/cart.blade.php
+++ b/resources/views/front/cart.blade.php
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="{{ asset('css/output.css') }}" rel="stylesheet">
+</head>
+<body class="font-poppins p-10">
+    <h1 class="text-2xl font-bold mb-4">Your Cart</h1>
+    <ul class="space-y-4">
+        @forelse($items as $item)
+            <li class="flex justify-between items-center border-b pb-2">
+                <span>{{ $item->course->name }}</span>
+                <form action="{{ route('cart.destroy', $item) }}" method="POST">
+                    @csrf
+                    @method('DELETE')
+                    <button class="text-red-600">Remove</button>
+                </form>
+            </li>
+        @empty
+            <li>No items in cart.</li>
+        @endforelse
+    </ul>
+</body>
+</html>

--- a/resources/views/front/category.blade.php
+++ b/resources/views/front/category.blade.php
@@ -89,6 +89,21 @@
         </div>
         @endif
 
+        <form method="GET" class="flex gap-4 mb-6">
+            <select name="course_type" class="border rounded p-2">
+                <option value="">All Types</option>
+                <option value="online" {{ request('course_type')=='online'?'selected':'' }}>Online</option>
+                <option value="onsite" {{ request('course_type')=='onsite'?'selected':'' }}>Onsite</option>
+            </select>
+            <select name="level" class="border rounded p-2">
+                <option value="">All Levels</option>
+                <option value="beginner" {{ request('level')=='beginner'?'selected':'' }}>Beginner</option>
+                <option value="intermediate" {{ request('level')=='intermediate'?'selected':'' }}>Intermediate</option>
+                <option value="advance" {{ request('level')=='advance'?'selected':'' }}>Advance</option>
+            </select>
+            <button class="px-4 py-2 bg-[#FF6129] text-white rounded">Filter</button>
+        </form>
+
         <!-- Course List -->
         <div class="grid grid-cols-3 gap-[30px] w-full">
             @forelse($courses as $course)
@@ -118,6 +133,12 @@
                         <div class="font-semibold text-lg">
                             {{ $course->price > 0 ? 'Rp ' . number_format($course->price, 0, ',', '.') : 'FREE' }}
                         </div>
+                        <p class="text-sm text-[#6D7786]">{{ ucfirst($course->category->course_type) }} - {{ ucfirst($course->category->level) }}</p>
+
+                        <form action="{{ route('cart.store', $course->slug) }}" method="POST">
+                            @csrf
+                            <button class="mt-2 px-4 py-2 bg-[#FF6129] text-white rounded w-full">Add to Cart</button>
+                        </form>
 
                         <div class="flex items-center gap-2">
                             <div class="w-8 h-8 flex shrink-0 rounded-full overflow-hidden">

--- a/resources/views/front/details.blade.php
+++ b/resources/views/front/details.blade.php
@@ -122,6 +122,10 @@
     <section id="Video-Resources" class="flex flex-col mt-5">
         <div class="max-w-[1100px] w-full mx-auto flex flex-col gap-3">
             <h1 class="title font-extrabold text-[30px] leading-[45px]">{{$course->name}}</h1>
+            <form action="{{ route('cart.store', $course->slug) }}" method="POST" class="my-2">
+                @csrf
+                <button class="px-4 py-2 bg-[#FF6129] text-white rounded">Add to Cart</button>
+            </form>
             <div class="flex items-center gap-5">
                 <div class="flex items-center gap-[6px]">
                     <div>

--- a/resources/views/front/index.blade.php
+++ b/resources/views/front/index.blade.php
@@ -115,6 +115,20 @@
                 <h2 class="font-bold text-[40px] leading-[60px]">Don’t Missed It, Learn Now</h2>
                 <p class="text-[#6D7786] text-lg -tracking-[2%]">Catching up the on demand skills and high paying career this year</p>
             </div>
+            <form method="GET" class="flex gap-4 mt-4">
+                <select name="course_type" class="border rounded p-2">
+                    <option value="">All Types</option>
+                    <option value="online" {{ request('course_type')=='online'?'selected':'' }}>Online</option>
+                    <option value="onsite" {{ request('course_type')=='onsite'?'selected':'' }}>Onsite</option>
+                </select>
+                <select name="level" class="border rounded p-2">
+                    <option value="">All Levels</option>
+                    <option value="beginner" {{ request('level')=='beginner'?'selected':'' }}>Beginner</option>
+                    <option value="intermediate" {{ request('level')=='intermediate'?'selected':'' }}>Intermediate</option>
+                    <option value="advance" {{ request('level')=='advance'?'selected':'' }}>Advance</option>
+                </select>
+                <button class="px-4 py-2 bg-[#FF6129] text-white rounded">Filter</button>
+            </form>
         </div>
         <div class="relative">
             <button class="btn-prev absolute rotate-180 -left-[52px] top-[216px]">
@@ -136,6 +150,12 @@
                             <div class="font-semibold text-lg line-clamp-2 hover:line-clamp-none min-h-[56px]">
                                 {{ $course->price > 0 ? 'Rp ' . number_format($course->price, 0, ',', '.') : 'FREE' }}
                             </div>
+                            <p class="text-sm text-[#6D7786]">{{ ucfirst($course->category->course_type) }} - {{ ucfirst($course->category->level) }}</p>
+
+                            <form action="{{ route('cart.store', $course->slug) }}" method="POST">
+                                @csrf
+                                <button class="mt-1 px-3 py-1 bg-[#FF6129] text-white rounded">Add to Cart</button>
+                            </form>
 
                             <div class="flex justify-between items-center">
                                 <div class="flex items-center gap-[2px]">

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,12 @@ Route::get('/details/{course:slug}', [FrontController::class, 'details'])->name(
 Route::get('/category/{category:slug}', [FrontController::class, 'category'])->name('front.category');
 
 Route::middleware(['auth', 'role:trainee'])->group(function () {
+    Route::get('/cart', [\App\Http\Controllers\CartController::class, 'index'])->name('cart.index');
+    Route::post('/cart/{course:slug}', [\App\Http\Controllers\CartController::class, 'store'])->name('cart.store');
+    Route::delete('/cart/{cartItem}', [\App\Http\Controllers\CartController::class, 'destroy'])->name('cart.destroy');
+});
+
+Route::middleware(['auth', 'role:trainee'])->group(function () {
     Route::get('/checkout/{course:slug}', [FrontController::class, 'checkout'])->name('front.checkout');
     Route::post('/checkout/{course:slug}/store', [FrontController::class, 'checkout_store'])->name('front.checkout.store');
 


### PR DESCRIPTION
## Summary
- extend categories with `course_type` and `level`
- create migrations for new category attributes and cart items
- add CartItem model and CartController
- show add to cart buttons in course views
- add filter forms for course type and level
- update validation and CRUD logic

## Testing
- `php` not installed, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6842cc4d99208321bf8b1a86ba356af7