### PR TITLE
Add course mode and level entities

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -53,9 +53,6 @@ class CategoryController extends Controller
 
             $validated['slug'] = Str::slug($validated['name']);
 
-            $validated['course_type'] = $request->input('course_type', 'online');
-            $validated['level'] = $request->input('level', 'beginner');
-
             $category = Category::create($validated);
 
         });
@@ -97,8 +94,6 @@ class CategoryController extends Controller
             }
 
             $validated['slug'] = Str::slug($validated['name']);
-            $validated['course_type'] = $request->input('course_type', $category->course_type);
-            $validated['level'] = $request->input('level', $category->level);
 
             $category ->update($validated);
 

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -7,6 +7,8 @@ use App\Http\Requests\UpdateCourseRequest;
 use App\Models\Category;
 use App\Models\Course;
 use App\Models\Trainer;
+use App\Models\CourseMode;
+use App\Models\CourseLevel;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -18,7 +20,7 @@ class CourseController extends Controller
     public function index()
     {
         $user = Auth::user();
-        $query = Course::with(['category', 'trainer.user', 'trainees', 'course_videos'])->orderByDesc('id');
+        $query = Course::with(['category', 'trainer.user', 'trainees', 'course_videos', 'mode', 'level'])->orderByDesc('id');
 
         if ($user->hasRole('trainer')) {
             $query->whereHas('trainer', function ($query) use ($user) {
@@ -34,7 +36,9 @@ class CourseController extends Controller
     public function create()
     {
         $categories = Category::all();
-        return view('admin.courses.create', compact('categories'));
+        $modes = CourseMode::all();
+        $levels = CourseLevel::all();
+        return view('admin.courses.create', compact('categories', 'modes', 'levels'));
     }
 
     public function store(StoreCourseRequest $request)
@@ -97,7 +101,9 @@ class CourseController extends Controller
         }
 
         $categories = Category::all();
-        return view('admin.courses.edit', compact('course', 'categories'));
+        $modes = CourseMode::all();
+        $levels = CourseLevel::all();
+        return view('admin.courses.edit', compact('course', 'categories', 'modes', 'levels'));
     }
 
     public function update(UpdateCourseRequest $request, Course $course)

--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreSubscribeTransactionRequest;
 use App\Models\Category;
 use App\Models\Course;
+use App\Models\CourseMode;
+use App\Models\CourseLevel;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\SubscribeTransaction;
@@ -17,24 +19,22 @@ class FrontController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Course::with(['category', 'trainer', 'trainees'])->orderByDesc('id');
+        $query = Course::with(['category', 'trainer', 'trainees', 'mode', 'level'])->orderByDesc('id');
 
-        if ($request->filled('course_type')) {
-            $query->whereHas('category', function ($q) use ($request) {
-                $q->where('course_type', $request->course_type);
-            });
+        if ($request->filled('course_mode_id')) {
+            $query->where('course_mode_id', $request->course_mode_id);
         }
 
-        if ($request->filled('level')) {
-            $query->whereHas('category', function ($q) use ($request) {
-                $q->where('level', $request->level);
-            });
+        if ($request->filled('course_level_id')) {
+            $query->where('course_level_id', $request->course_level_id);
         }
 
         $courses = $query->get();
         $categories = Category::all();
+        $modes = CourseMode::all();
+        $levels = CourseLevel::all();
 
-        return view('front.index', compact('courses', 'categories'));
+        return view('front.index', compact('courses', 'categories', 'modes', 'levels'));
     }
 
     /**
@@ -47,25 +47,23 @@ class FrontController extends Controller
 
     public function category(Request $request, Category $category)
     {
-        $query = $category->courses();
+        $query = $category->courses()->with(['mode', 'level']);
 
-        if ($request->filled('course_type')) {
-            $query->whereHas('category', function ($q) use ($request) {
-                $q->where('course_type', $request->course_type);
-            });
+        if ($request->filled('course_mode_id')) {
+            $query->where('course_mode_id', $request->course_mode_id);
         }
 
-        if ($request->filled('level')) {
-            $query->whereHas('category', function ($q) use ($request) {
-                $q->where('level', $request->level);
-            });
+        if ($request->filled('course_level_id')) {
+            $query->where('course_level_id', $request->course_level_id);
         }
 
         $courses = $query->get();
 
         $otherCategories = Category::where('id', '!=', $category->id)->get();
+        $modes = CourseMode::all();
+        $levels = CourseLevel::all();
 
-        return view('front.category', compact('courses', 'category', 'otherCategories'));
+        return view('front.category', compact('courses', 'category', 'otherCategories', 'modes', 'levels'));
     }
 
     /**

--- a/app/Http/Requests/StoreCategoryRequest.php
+++ b/app/Http/Requests/StoreCategoryRequest.php
@@ -24,8 +24,6 @@ class StoreCategoryRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'icon' => ['required', 'image', 'mimes:png,jpg,jpeg'],
-            'course_type' => ['required', 'in:online,onsite'],
-            'level' => ['required', 'in:beginner,intermediate,advance'],
         ];
     }
 }

--- a/app/Http/Requests/StoreCourseRequest.php
+++ b/app/Http/Requests/StoreCourseRequest.php
@@ -27,6 +27,8 @@ class StoreCourseRequest extends FormRequest
             'path_trailer' => 'required|string|max:255',
             'about' => 'required|string|max:255',
             'category_id' => 'required|string|max:255',
+            'course_mode_id' => 'required|exists:course_modes,id',
+            'course_level_id' => 'required|exists:course_levels,id',
             'thumbnail' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048',
             'price' => 'required|numeric|min:0',
             'course_keypoints.*' => 'required|string|max:255',

--- a/app/Http/Requests/UpdateCategoryRequest.php
+++ b/app/Http/Requests/UpdateCategoryRequest.php
@@ -24,8 +24,6 @@ class UpdateCategoryRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'icon' => ['sometimes', 'image', 'mimes:png,jpg,jpeg'],
-            'course_type' => ['required', 'in:online,onsite'],
-            'level' => ['required', 'in:beginner,intermediate,advance'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateCourseRequest.php
+++ b/app/Http/Requests/UpdateCourseRequest.php
@@ -27,6 +27,8 @@ class UpdateCourseRequest extends FormRequest
             'path_trailer' => 'required|string|max:255',
             'about' => 'required|string|max:255',
             'category_id' => 'required|string|max:255',
+            'course_mode_id' => 'required|exists:course_modes,id',
+            'course_level_id' => 'required|exists:course_levels,id',
             'thumbnail' => 'sometimes|string|max:255',
             'price' => 'required|numeric|min:0',
             'course_keypoints.*' => 'required|string|max:255',

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -13,9 +13,7 @@ class Category extends Model
         'name',
         'slug',
         'icon',
-        'email',
-        'course_type',
-        'level'
+        'email'
     ];
 
     protected $guarded =[

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -18,7 +18,9 @@ class Course extends Model
         'price',
         'trainer',
         'category_id',
-        'trainer_id'
+        'trainer_id',
+        'course_mode_id',
+        'course_level_id'
     ];
 
     public function category(){
@@ -27,6 +29,16 @@ class Course extends Model
     }
     public function trainer(){
             return $this->belongsTo(Trainer::class);
+    }
+
+    public function mode()
+    {
+        return $this->belongsTo(CourseMode::class, 'course_mode_id');
+    }
+
+    public function level()
+    {
+        return $this->belongsTo(CourseLevel::class, 'course_level_id');
     }
 
     public function course_videos(){

--- a/app/Models/CourseLevel.php
+++ b/app/Models/CourseLevel.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CourseLevel extends Model
+{
+    use HasFactory;
+    protected $fillable = ['name','slug'];
+
+    public function courses()
+    {
+        return $this->hasMany(Course::class);
+    }
+}

--- a/app/Models/CourseMode.php
+++ b/app/Models/CourseMode.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CourseMode extends Model
+{
+    use HasFactory;
+    protected $fillable = ['name','slug'];
+
+    public function courses()
+    {
+        return $this->hasMany(Course::class);
+    }
+}

--- a/database/migrations/2025_08_02_000000_create_course_modes_table.php
+++ b/database/migrations/2025_08_02_000000_create_course_modes_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('course_modes', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('course_modes');
+    }
+};

--- a/database/migrations/2025_08_02_000001_create_course_levels_table.php
+++ b/database/migrations/2025_08_02_000001_create_course_levels_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('course_levels', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('course_levels');
+    }
+};

--- a/database/migrations/2025_08_02_000002_add_mode_and_level_to_courses_table.php
+++ b/database/migrations/2025_08_02_000002_add_mode_and_level_to_courses_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->foreignId('course_mode_id')->nullable()->constrained('course_modes');
+            $table->foreignId('course_level_id')->nullable()->constrained('course_levels');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('course_mode_id');
+            $table->dropConstrainedForeignId('course_level_id');
+        });
+    }
+};

--- a/database/migrations/2025_08_02_000003_remove_mode_and_level_from_categories_table.php
+++ b/database/migrations/2025_08_02_000003_remove_mode_and_level_from_categories_table.php
@@ -1,0 +1,26 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            if (Schema::hasColumn('categories', 'course_type')) {
+                $table->dropColumn('course_type');
+            }
+            if (Schema::hasColumn('categories', 'level')) {
+                $table->dropColumn('level');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->enum('course_type', ['online', 'onsite'])->default('online');
+            $table->enum('level', ['beginner', 'intermediate', 'advance'])->default('beginner');
+        });
+    }
+};

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -32,24 +32,6 @@
                         <x-input-error :messages="$errors->get('icon')" class="mt-2" />
                     </div>
 
-                    <div class="mt-4">
-                        <x-input-label for="course_type" :value="__('Course Type')" />
-                        <select id="course_type" name="course_type" class="block mt-1 w-full border-gray-300 rounded">
-                            <option value="online">Online</option>
-                            <option value="onsite">Onsite</option>
-                        </select>
-                        <x-input-error :messages="$errors->get('course_type')" class="mt-2" />
-                    </div>
-
-                    <div class="mt-4">
-                        <x-input-label for="level" :value="__('Level')" />
-                        <select id="level" name="level" class="block mt-1 w-full border-gray-300 rounded">
-                            <option value="beginner">Beginner</option>
-                            <option value="intermediate">Intermediate</option>
-                            <option value="advance">Advance</option>
-                        </select>
-                        <x-input-error :messages="$errors->get('level')" class="mt-2" />
-                    </div>
 
                     <div class="flex items-center justify-end mt-4">
             

--- a/resources/views/admin/categories/edit.blade.php
+++ b/resources/views/admin/categories/edit.blade.php
@@ -34,24 +34,6 @@
                         <x-input-error :messages="$errors->get('icon')" class="mt-2" />
                     </div>
 
-                    <div class="mt-4">
-                        <x-input-label for="course_type" :value="__('Course Type')" />
-                        <select id="course_type" name="course_type" class="block mt-1 w-full border-gray-300 rounded">
-                            <option value="online" {{ $category->course_type == 'online' ? 'selected' : '' }}>Online</option>
-                            <option value="onsite" {{ $category->course_type == 'onsite' ? 'selected' : '' }}>Onsite</option>
-                        </select>
-                        <x-input-error :messages="$errors->get('course_type')" class="mt-2" />
-                    </div>
-
-                    <div class="mt-4">
-                        <x-input-label for="level" :value="__('Level')" />
-                        <select id="level" name="level" class="block mt-1 w-full border-gray-300 rounded">
-                            <option value="beginner" {{ $category->level == 'beginner' ? 'selected' : '' }}>Beginner</option>
-                            <option value="intermediate" {{ $category->level == 'intermediate' ? 'selected' : '' }}>Intermediate</option>
-                            <option value="advance" {{ $category->level == 'advance' ? 'selected' : '' }}>Advance</option>
-                        </select>
-                        <x-input-error :messages="$errors->get('level')" class="mt-2" />
-                    </div>
 
                     <div class="flex items-center justify-end mt-4">
             

--- a/resources/views/admin/courses/create.blade.php
+++ b/resources/views/admin/courses/create.blade.php
@@ -46,7 +46,7 @@
 
                     <div class="mt-4">
                         <x-input-label for="category" :value="__('category')" />
-                        
+
                         <select name="category_id" id="category_id" class="py-3 rounded-lg pl-3 w-full border border-slate-300">
                             <option value="">Choose category</option>
                             @forelse($categories as $category)
@@ -56,6 +56,28 @@
                         </select>
 
                         <x-input-error :messages="$errors->get('category')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-input-label for="course_mode_id" :value="__('Mode')" />
+                        <select name="course_mode_id" id="course_mode_id" class="py-3 rounded-lg pl-3 w-full border border-slate-300">
+                            <option value="">Choose mode</option>
+                            @foreach($modes as $mode)
+                                <option value="{{$mode->id}}">{{$mode->name}}</option>
+                            @endforeach
+                        </select>
+                        <x-input-error :messages="$errors->get('course_mode_id')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-input-label for="course_level_id" :value="__('Level')" />
+                        <select name="course_level_id" id="course_level_id" class="py-3 rounded-lg pl-3 w-full border border-slate-300">
+                            <option value="">Choose level</option>
+                            @foreach($levels as $level)
+                                <option value="{{$level->id}}">{{$level->name}}</option>
+                            @endforeach
+                        </select>
+                        <x-input-error :messages="$errors->get('course_level_id')" class="mt-2" />
                     </div>
 
                     <div class="mt-4">

--- a/resources/views/admin/courses/edit.blade.php
+++ b/resources/views/admin/courses/edit.blade.php
@@ -62,6 +62,28 @@
                     </div>
 
                     <div class="mt-4">
+                        <x-input-label for="course_mode_id" :value="__('Mode')" />
+                        <select name="course_mode_id" id="course_mode_id" class="py-3 rounded-lg pl-3 w-full border border-slate-300">
+                            <option value="">Choose mode</option>
+                            @foreach($modes as $mode)
+                                <option value="{{ $mode->id }}" {{ $course->course_mode_id == $mode->id ? 'selected' : '' }}>{{ $mode->name }}</option>
+                            @endforeach
+                        </select>
+                        <x-input-error :messages="$errors->get('course_mode_id')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-input-label for="course_level_id" :value="__('Level')" />
+                        <select name="course_level_id" id="course_level_id" class="py-3 rounded-lg pl-3 w-full border border-slate-300">
+                            <option value="">Choose level</option>
+                            @foreach($levels as $level)
+                                <option value="{{ $level->id }}" {{ $course->course_level_id == $level->id ? 'selected' : '' }}>{{ $level->name }}</option>
+                            @endforeach
+                        </select>
+                        <x-input-error :messages="$errors->get('course_level_id')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
                         <x-input-label for="about" :value="__('About')" />
                         <textarea name="about" id="about" cols="30" rows="5" class="border border-slate-300 rounded-xl w-full">{{ $course->about }}</textarea>
                         <x-input-error :messages="$errors->get('about')" class="mt-2" />

--- a/resources/views/front/category.blade.php
+++ b/resources/views/front/category.blade.php
@@ -90,16 +90,17 @@
         @endif
 
         <form method="GET" class="flex gap-4 mb-6">
-            <select name="course_type" class="border rounded p-2">
-                <option value="">All Types</option>
-                <option value="online" {{ request('course_type')=='online'?'selected':'' }}>Online</option>
-                <option value="onsite" {{ request('course_type')=='onsite'?'selected':'' }}>Onsite</option>
+            <select name="course_mode_id" class="border rounded p-2">
+                <option value="">All Modes</option>
+                @foreach($modes as $mode)
+                    <option value="{{ $mode->id }}" {{ request('course_mode_id')==$mode->id?'selected':'' }}>{{ $mode->name }}</option>
+                @endforeach
             </select>
-            <select name="level" class="border rounded p-2">
+            <select name="course_level_id" class="border rounded p-2">
                 <option value="">All Levels</option>
-                <option value="beginner" {{ request('level')=='beginner'?'selected':'' }}>Beginner</option>
-                <option value="intermediate" {{ request('level')=='intermediate'?'selected':'' }}>Intermediate</option>
-                <option value="advance" {{ request('level')=='advance'?'selected':'' }}>Advance</option>
+                @foreach($levels as $level)
+                    <option value="{{ $level->id }}" {{ request('course_level_id')==$level->id?'selected':'' }}>{{ $level->name }}</option>
+                @endforeach
             </select>
             <button class="px-4 py-2 bg-[#FF6129] text-white rounded">Filter</button>
         </form>
@@ -133,7 +134,7 @@
                         <div class="font-semibold text-lg">
                             {{ $course->price > 0 ? 'Rp ' . number_format($course->price, 0, ',', '.') : 'FREE' }}
                         </div>
-                        <p class="text-sm text-[#6D7786]">{{ ucfirst($course->category->course_type) }} - {{ ucfirst($course->category->level) }}</p>
+                        <p class="text-sm text-[#6D7786]">{{ $course->mode->name ?? '' }} - {{ $course->level->name ?? '' }}</p>
 
                         <form action="{{ route('cart.store', $course->slug) }}" method="POST">
                             @csrf

--- a/resources/views/front/index.blade.php
+++ b/resources/views/front/index.blade.php
@@ -116,16 +116,17 @@
                 <p class="text-[#6D7786] text-lg -tracking-[2%]">Catching up the on demand skills and high paying career this year</p>
             </div>
             <form method="GET" class="flex gap-4 mt-4">
-                <select name="course_type" class="border rounded p-2">
-                    <option value="">All Types</option>
-                    <option value="online" {{ request('course_type')=='online'?'selected':'' }}>Online</option>
-                    <option value="onsite" {{ request('course_type')=='onsite'?'selected':'' }}>Onsite</option>
+                <select name="course_mode_id" class="border rounded p-2">
+                    <option value="">All Modes</option>
+                    @foreach($modes as $mode)
+                        <option value="{{ $mode->id }}" {{ request('course_mode_id')==$mode->id?'selected':'' }}>{{ $mode->name }}</option>
+                    @endforeach
                 </select>
-                <select name="level" class="border rounded p-2">
+                <select name="course_level_id" class="border rounded p-2">
                     <option value="">All Levels</option>
-                    <option value="beginner" {{ request('level')=='beginner'?'selected':'' }}>Beginner</option>
-                    <option value="intermediate" {{ request('level')=='intermediate'?'selected':'' }}>Intermediate</option>
-                    <option value="advance" {{ request('level')=='advance'?'selected':'' }}>Advance</option>
+                    @foreach($levels as $level)
+                        <option value="{{ $level->id }}" {{ request('course_level_id')==$level->id?'selected':'' }}>{{ $level->name }}</option>
+                    @endforeach
                 </select>
                 <button class="px-4 py-2 bg-[#FF6129] text-white rounded">Filter</button>
             </form>
@@ -150,7 +151,7 @@
                             <div class="font-semibold text-lg line-clamp-2 hover:line-clamp-none min-h-[56px]">
                                 {{ $course->price > 0 ? 'Rp ' . number_format($course->price, 0, ',', '.') : 'FREE' }}
                             </div>
-                            <p class="text-sm text-[#6D7786]">{{ ucfirst($course->category->course_type) }} - {{ ucfirst($course->category->level) }}</p>
+                            <p class="text-sm text-[#6D7786]">{{ $course->mode->name ?? '' }} - {{ $course->level->name ?? '' }}</p>
 
                             <form action="{{ route('cart.store', $course->slug) }}" method="POST">
                                 @csrf


### PR DESCRIPTION
## Summary
- create migrations for course_modes and course_levels
- link courses to modes and levels
- drop old type/level columns from categories
- require course_mode_id and course_level_id in requests
- update controllers and views to use new relations
- adjust front pages for filtering by mode and level

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d36b74a48321ad27a6401bb1f6a5