### PR TITLE
Add unique index for cart items

### DIFF
--- a/database/migrations/2025_08_01_010000_create_cart_items_table.php
+++ b/database/migrations/2025_08_01_010000_create_cart_items_table.php
@@ -12,6 +12,7 @@ return new class extends Migration {
             $table->foreignId('course_id')->constrained()->onDelete('cascade');
             $table->unsignedInteger('quantity')->default(1);
             $table->timestamps();
+            $table->unique(['user_id', 'course_id']);
         });
     }
 


### PR DESCRIPTION
## Summary
- ensure cart items are unique per user/course by adding a composite unique index to the migration

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d3a0515883219694bb8ade7c9348