### PR TITLE
Add order field for videos and quizzes

### DIFF
--- a/app/Http/Controllers/FinalQuizController.php
+++ b/app/Http/Controllers/FinalQuizController.php
@@ -75,12 +75,13 @@ class FinalQuizController extends Controller
             'course_id' => 'required|exists:courses,id',
             'title' => 'required|string|max:255',
             'passing_score' => 'required|integer|min:0|max:100',
+            'order' => 'nullable|integer|min:0',
             'is_hidden_from_trainee' => 'sometimes|boolean', // Add this validation
             'questions' => 'required|array|min:1',
             'questions.*.text' => 'required|string',
-            'questions.*.options' => 'required|array|size:4', 
+            'questions.*.options' => 'required|array|size:4',
             'questions.*.options.*.text' => 'required|string',
-            'questions.*.correct_option' => 'required|integer|min:0|max:3', 
+            'questions.*.correct_option' => 'required|integer|min:0|max:3',
         ]);
 
         DB::beginTransaction();
@@ -91,6 +92,7 @@ class FinalQuizController extends Controller
                 'course_id'     => $validatedData['course_id'],
                 'title'         => $validatedData['title'],
                 'passing_score' => $validatedData['passing_score'],
+                'order'        => $validatedData['order'] ?? 0,
                 'is_hidden_from_trainee' => $request->has('is_hidden_from_trainee'), // Process checkbox
             ]);
 
@@ -140,7 +142,7 @@ class FinalQuizController extends Controller
             }
         }
 
-        $quiz = $course->finalQuizzes()->with(['questions.options'])->first();
+        $quiz = $course->finalQuizzes()->orderBy('order')->with(['questions.options'])->first();
 
         if (!$quiz) {
             return redirect()->route('admin.course_quiz.create', $course)->with('info', 'No quiz found for this course. You can create one.');
@@ -166,9 +168,10 @@ class FinalQuizController extends Controller
         $validatedData = $request->validate([
             'title' => 'required|string|max:255',
             'passing_score' => 'required|integer|min:0|max:100',
+            'order' => 'nullable|integer|min:0',
             'is_hidden_from_trainee' => 'sometimes|boolean', // Add this validation
             'questions' => 'required|array|min:1',
-            'questions.*.id' => 'nullable|exists:quiz_questions,id', 
+            'questions.*.id' => 'nullable|exists:quiz_questions,id',
             'questions.*.text' => 'required|string', 
             'questions.*.options' => 'required|array|size:4',
             'questions.*.options.*.id' => 'nullable|exists:quiz_options,id', 
@@ -185,6 +188,7 @@ class FinalQuizController extends Controller
             $finalQuiz->update([
                 'title'         => $validatedData['title'],
                 'passing_score' => $validatedData['passing_score'],
+                'order'        => $validatedData['order'] ?? $finalQuiz->order,
                 'is_hidden_from_trainee' => $request->has('is_hidden_from_trainee'), // Process checkbox
             ]);
 

--- a/app/Http/Controllers/QuizAttemptController.php
+++ b/app/Http/Controllers/QuizAttemptController.php
@@ -12,6 +12,7 @@ class QuizAttemptController extends Controller
     public function show(Course $course) // Laravel akan otomatis mengambil objek Course berdasarkan ID dari URL
     {
         $quiz = FinalQuiz::where('course_id', $course->id)
+                         ->orderBy('order')
                          ->with('questions.options') // Pastikan relasi 'options' ada di model QuizQuestion
                          ->firstOrFail(); // Ambil kuis pertama yang terkait dengan kursus ini
 

--- a/app/Http/Requests/StoreCourseVideoRequest.php
+++ b/app/Http/Requests/StoreCourseVideoRequest.php
@@ -25,6 +25,7 @@ class StoreCourseVideoRequest extends FormRequest
             //
             'name' => 'required|string|max:255',
             'path_video' => 'required|string|max:255',
+            'order' => 'nullable|integer|min:0',
         ];
     }
 }

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -42,7 +42,7 @@ class Course extends Model
     }
 
     public function course_videos(){
-        return $this->hasMany(CourseVideo::class);
+        return $this->hasMany(CourseVideo::class)->orderBy('order');
     }
 
     public function course_keypoints(){
@@ -63,12 +63,12 @@ public function subscribeTransactions()
 
 public function finalQuizzes()
 {
-    return $this->hasMany(FinalQuiz::class);
+    return $this->hasMany(FinalQuiz::class)->orderBy('order');
 }
 
 public function finalQuiz()
 {
-    return $this->hasOne(FinalQuiz::class);
+    return $this->hasOne(FinalQuiz::class)->orderBy('order');
 }
 
 

--- a/app/Models/CourseVideo.php
+++ b/app/Models/CourseVideo.php
@@ -13,7 +13,8 @@ class CourseVideo extends Model
     protected $fillable = [
         'name',
         'path_video',
-        'course_id'
+        'course_id',
+        'order'
     ];
 
     public function course(){

--- a/app/Models/FinalQuiz.php
+++ b/app/Models/FinalQuiz.php
@@ -14,6 +14,7 @@ class FinalQuiz extends Model
         'title',
         'passing_score',
         'is_hidden_from_trainee', // Add this line
+        'order'
     ];
 
     protected $casts = [

--- a/database/migrations/2025_08_02_000004_add_order_to_course_videos_and_final_quizzes.php
+++ b/database/migrations/2025_08_02_000004_add_order_to_course_videos_and_final_quizzes.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('course_videos', function (Blueprint $table) {
+            $table->integer('order')->default(0)->after('path_video');
+        });
+
+        Schema::table('final_quizzes', function (Blueprint $table) {
+            $table->integer('order')->default(0)->after('passing_score');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('course_videos', function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+
+        Schema::table('final_quizzes', function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+    }
+};

--- a/resources/views/admin/course_quiz/create.blade.php
+++ b/resources/views/admin/course_quiz/create.blade.php
@@ -30,6 +30,11 @@
                     </div>
 
                     <div class="mb-4">
+                        <x-input-label for="order" value="Order" />
+                        <x-text-input id="order" name="order" type="number" class="w-full" value="{{ old('order', 0) }}" min="0" />
+                    </div>
+
+                    <div class="mb-4">
                         <label for="is_hidden_from_trainee" class="block text-sm font-medium text-gray-700 mb-1">Visibility</label>
                         <div class="flex items-center">
                             <input id="is_hidden_from_trainee" name="is_hidden_from_trainee" type="checkbox" value="1" 

--- a/resources/views/admin/course_quiz/edit.blade.php
+++ b/resources/views/admin/course_quiz/edit.blade.php
@@ -49,9 +49,15 @@
 
                     <div class="mb-4">
                         <x-input-label for="passing_score" value="Passing Score (%)" />
-                        <x-text-input id="passing_score" name="passing_score" type="number" class="w-full" 
+                        <x-text-input id="passing_score" name="passing_score" type="number" class="w-full"
                                       min="0" max="100" value="{{ old('passing_score', $quiz->passing_score) }}" required />
                         <x-input-error :messages="$errors->get('passing_score')" class="mt-2" />
+                    </div>
+
+                    <div class="mb-4">
+                        <x-input-label for="order" value="Order" />
+                        <x-text-input id="order" name="order" type="number" class="w-full" value="{{ old('order', $quiz->order) }}" min="0" />
+                        <x-input-error :messages="$errors->get('order')" class="mt-2" />
                     </div>
 
                     <div class="mb-4">

--- a/resources/views/admin/course_videos/create.blade.php
+++ b/resources/views/admin/course_videos/create.blade.php
@@ -48,6 +48,12 @@
                         <x-input-error :messages="$errors->get('path_video')" class="mt-2" />
                     </div>
 
+                    <div class="mt-4">
+                        <x-input-label for="order" :value="__('Order')" />
+                        <x-text-input id="order" class="block mt-1 w-full" type="number" name="order" :value="old('order', 0)" min="0" />
+                        <x-input-error :messages="$errors->get('order')" class="mt-2" />
+                    </div>
+
                     <div class="flex items-center justify-end mt-4">
             
                         <button type="submit" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">

--- a/resources/views/admin/course_videos/edit.blade.php
+++ b/resources/views/admin/course_videos/edit.blade.php
@@ -49,6 +49,12 @@
                         <x-input-error :messages="$errors->get('path_video')" class="mt-2" />
                     </div>
 
+                    <div class="mt-4">
+                        <x-input-label for="order" :value="__('Order')" />
+                        <x-text-input id="order" class="block mt-1 w-full" type="number" name="order" :value="$courseVideo->order" min="0" />
+                        <x-input-error :messages="$errors->get('order')" class="mt-2" />
+                    </div>
+
                     <div class="flex items-center justify-end mt-4">
             
                         <button type="submit" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">


### PR DESCRIPTION
## Summary
- add order columns via migration
- update Course model relationships to order by `order`
- allow `order` mass assignment on CourseVideo and FinalQuiz models
- support setting order in CourseVideo and FinalQuiz forms and controllers
- query videos/quizzes ordered by `order`

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6dc9ef48321b6e93e64487691c5