### PR TITLE
Add admin modules views and routing

### DIFF
--- a/app/Http/Controllers/ModuleController.php
+++ b/app/Http/Controllers/ModuleController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use App\Models\Course;
+use App\Models\Module;
+
+class ModuleController extends Controller
+{
+    /**
+     * Display a listing of the modules for a course.
+     */
+    public function index(Course $course)
+    {
+        $modules = $course->modules()->orderBy('order')->get();
+        return view('admin.modules.index', compact('course', 'modules'));
+    }
+
+    /**
+     * Show the form for creating a new module.
+     */
+    public function create(Course $course)
+    {
+        return view('admin.modules.create', compact('course'));
+    }
+
+    /**
+     * Store a newly created module in storage.
+     */
+    public function store(Request $request, Course $course)
+    {
+        $validated = $request->validate([
+            'name'  => 'required|string|max:255',
+            'order' => 'nullable|integer'
+        ]);
+        $validated['course_id'] = $course->id;
+        Module::create($validated);
+        return redirect()->route('admin.modules.index', $course);
+    }
+
+    /**
+     * Show the form for editing the specified module.
+     */
+    public function edit(Course $course, Module $module)
+    {
+        return view('admin.modules.edit', compact('course', 'module'));
+    }
+
+    /**
+     * Update the specified module in storage.
+     */
+    public function update(Request $request, Course $course, Module $module)
+    {
+        $validated = $request->validate([
+            'name'  => 'required|string|max:255',
+            'order' => 'nullable|integer'
+        ]);
+        $module->update($validated);
+        return redirect()->route('admin.modules.index', $course);
+    }
+
+    /**
+     * Remove the specified module from storage.
+     */
+    public function destroy(Course $course, Module $module)
+    {
+        DB::transaction(function () use ($module) {
+            $module->delete();
+        });
+        return redirect()->route('admin.modules.index', $course);
+    }
+}

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -71,5 +71,10 @@ public function finalQuiz()
     return $this->hasOne(FinalQuiz::class);
 }
 
+public function modules()
+{
+    return $this->hasMany(\App\Models\Module::class);
+}
+
 
 }

--- a/app/Models/Material.php
+++ b/app/Models/Material.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Material extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'module_id',
+        'name',
+        'content'
+    ];
+
+    public function module()
+    {
+        return $this->belongsTo(Module::class);
+    }
+}

--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Module extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'course_id',
+        'name',
+        'order'
+    ];
+
+    public function course()
+    {
+        return $this->belongsTo(Course::class);
+    }
+
+    public function materials()
+    {
+        return $this->hasMany(Material::class);
+    }
+}

--- a/database/migrations/2025_08_03_000000_create_modules_table.php
+++ b/database/migrations/2025_08_03_000000_create_modules_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('modules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->integer('order')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('modules');
+    }
+};

--- a/database/migrations/2025_08_03_000001_create_materials_table.php
+++ b/database/migrations/2025_08_03_000001_create_materials_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('materials', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('module_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->text('content')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('materials');
+    }
+};

--- a/resources/views/admin/courses/edit.blade.php
+++ b/resources/views/admin/courses/edit.blade.php
@@ -100,15 +100,29 @@
                             @endphp
                             @for ($i = 0; $i < 4; $i++)
                                 <input type="text" class="py-3 rounded-lg border-slate-300 border" placeholder="Write your keypoint" name="course_keypoints[]" value="{{ $keypoints[$i] ?? '' }}">
-                            @endfor
-                        </div>
-                        <x-input-error :messages="$errors->get('keypoints')" class="mt-2" />
-                    </div>
+                    @endfor
+                </div>
+                <x-input-error :messages="$errors->get('keypoints')" class="mt-2" />
+            </div>
 
-                    <div class="flex items-center justify-end mt-4">
-                        <button type="submit" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">
-                            Update Course
-                        </button>
+            {{-- Modules management --}}
+            <div class="mt-8">
+                <h3 class="text-lg font-bold mb-2">Modules</h3>
+                <a href="{{ route('admin.modules.index', $course) }}" class="text-indigo-700 underline">Manage Modules</a>
+            </div>
+
+            {{-- Materials, Videos, Quizzes placeholders --}}
+            <div class="mt-8 flex flex-col gap-y-2">
+                <h3 class="text-lg font-bold">Materials & Videos</h3>
+                <p class="text-sm text-slate-500">Manage materials and videos from the module management page.</p>
+                <h3 class="text-lg font-bold mt-4">Quizzes</h3>
+                <a href="{{ route('admin.course_quiz.edit', $course) }}" class="text-indigo-700 underline">Manage Quiz</a>
+            </div>
+
+            <div class="flex items-center justify-end mt-4">
+                <button type="submit" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">
+                    Update Course
+                </button>
                     </div>
                 </form>
 

--- a/resources/views/admin/modules/create.blade.php
+++ b/resources/views/admin/modules/create.blade.php
@@ -1,0 +1,28 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Create Module') }} - {{ $course->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden p-10 shadow-sm sm:rounded-lg">
+                <form method="POST" action="{{ route('admin.modules.store', $course) }}">
+                    @csrf
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" required />
+                    </div>
+                    <div class="mt-4">
+                        <x-input-label for="order" :value="__('Order')" />
+                        <x-text-input id="order" class="block mt-1 w-20" type="number" name="order" />
+                    </div>
+                    <div class="flex items-center justify-end mt-4">
+                        <button type="submit" class="font-bold py-2 px-6 bg-indigo-700 text-white rounded-full">Save</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/modules/edit.blade.php
+++ b/resources/views/admin/modules/edit.blade.php
@@ -1,0 +1,29 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Module') }} - {{ $course->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden p-10 shadow-sm sm:rounded-lg">
+                <form method="POST" action="{{ route('admin.modules.update', [$course, $module]) }}">
+                    @csrf
+                    @method('PUT')
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="$module->name" required />
+                    </div>
+                    <div class="mt-4">
+                        <x-input-label for="order" :value="__('Order')" />
+                        <x-text-input id="order" class="block mt-1 w-20" type="number" name="order" :value="$module->order" />
+                    </div>
+                    <div class="flex items-center justify-end mt-4">
+                        <button type="submit" class="font-bold py-2 px-6 bg-indigo-700 text-white rounded-full">Update</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/modules/index.blade.php
+++ b/resources/views/admin/modules/index.blade.php
@@ -1,0 +1,25 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Modules') }} - {{ $course->name }}
+            </h2>
+            <a href="{{ route('admin.modules.create', $course) }}" class="font-bold py-2 px-4 bg-indigo-700 text-white rounded-full">Add Module</a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-10 flex flex-col gap-y-5">
+                @forelse($modules as $module)
+                    <div class="flex items-center justify-between">
+                        <div>{{ $module->name }}</div>
+                        <input type="number" name="orders[{{ $module->id }}]" value="{{ $module->order }}" class="border rounded w-20 p-1">
+                    </div>
+                @empty
+                    <p>No modules available.</p>
+                @endforelse
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\{
     CategoryController,
     CourseController,
     CourseVideoController,
+    ModuleController,
     SubscribeTransactionController,
     TrainerController,
     FinalQuizController,
@@ -78,6 +79,7 @@ Route::middleware('auth')->group(function () {
         Route::middleware('role:admin|trainer')->group(function () {
             Route::resource('courses', CourseController::class);
             Route::resource('course_videos', CourseVideoController::class);
+            Route::resource('courses.modules', ModuleController::class);
 
             Route::get('/add/video/{course:id}', [CourseVideoController::class, 'create'])->name('course.add_video');
             Route::post('/add/video/save/{course:id}', [CourseVideoController::class, 'store'])->name('course.add_video.save');


### PR DESCRIPTION
## Summary
- scaffold basic Module management: models, migration, controller
- add module views for index, create and edit
- link modules in course edit page
- expose routes for module controller

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6ea26888321b20fda36e29512b7