### PR TITLE
Implement course material uploads

### DIFF
--- a/app/Http/Controllers/CourseMaterialController.php
+++ b/app/Http/Controllers/CourseMaterialController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class CourseMaterialController extends Controller
+{
+    /**
+     * Display a listing of materials.
+     */
+    public function index()
+    {
+        $files = collect(Storage::disk('public')->files('materials'));
+        return view('materials.index', ['files' => $files]);
+    }
+
+    /**
+     * Store a newly uploaded material.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'material' => 'required|file|mimes:pdf,doc,docx,ppt,pptx|max:5120',
+        ]);
+
+        $path = Storage::disk('public')->putFile('materials', $validated['material']);
+
+        return back()->with('material_path', $path);
+    }
+}
+

--- a/resources/views/materials/index.blade.php
+++ b/resources/views/materials/index.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <h1>Course Materials</h1>
+        <ul>
+            @foreach($files as $file)
+                <li><a href="{{ Storage::url($file) }}" download>{{ basename($file) }}</a></li>
+            @endforeach
+        </ul>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\{
     TalentController,
     RecruiterController,
     TalentDiscoveryController,
+    CourseMaterialController,
 };
 // ====================
 // FRONTEND ROUTES
@@ -78,6 +79,10 @@ Route::middleware('auth')->group(function () {
         Route::middleware('role:admin|trainer')->group(function () {
             Route::resource('courses', CourseController::class);
             Route::resource('course_videos', CourseVideoController::class);
+
+            // Course Materials
+            Route::get('courses/materials', [CourseMaterialController::class, 'index'])->name('materials.index');
+            Route::post('courses/materials', [CourseMaterialController::class, 'store'])->name('materials.store');
 
             Route::get('/add/video/{course:id}', [CourseVideoController::class, 'create'])->name('course.add_video');
             Route::post('/add/video/save/{course:id}', [CourseVideoController::class, 'store'])->name('course.add_video.save');


### PR DESCRIPTION
## Summary
- add `CourseMaterialController` with upload validation and storage to the public disk
- list uploaded materials with download links
- wire controller routes for admins and trainers

## Testing
- `php -v` *(fails: command not found)*
- `composer --no-interaction update` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6845a6e86bc48321b85145996e468d31