### PR TITLE
Add course modules table and relations

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -50,6 +50,11 @@ class Course extends Model
         return $this->hasMany(CourseKeypoint::class);
     }
 
+    public function modules()
+    {
+        return $this->hasMany(CourseModule::class);
+    }
+
     // App\Models\Course.php
 
 public function trainees()

--- a/app/Models/CourseModule.php
+++ b/app/Models/CourseModule.php
@@ -15,6 +15,11 @@ class CourseModule extends Model
         'order',
     ];
 
+    public function course()
+    {
+        return $this->belongsTo(Course::class);
+    }
+
     public function materials()
     {
         return $this->hasMany(CourseMaterial::class);

--- a/database/migrations/2025_08_01_020000_create_course_modules_table.php
+++ b/database/migrations/2025_08_01_020000_create_course_modules_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('course_modules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->unsignedInteger('order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('course_modules');
+    }
+};


### PR DESCRIPTION
## Summary
- add migration to create `course_modules`
- link CourseModule to Course and allow Course to have many modules

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684667e3011c8321a2f4836eafbed0de