### PR TITLE
Add modules relation to Course and eager load

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -177,11 +177,15 @@ class CourseController extends Controller
 
     public function show(Course $course)
     {
+        $course->load(['category', 'trainer.user', 'trainees', 'course_videos', 'course_keypoints', 'modules']);
+
         return view('admin.courses.show', compact('course'));
     }
 
     public function edit(Course $course)
     {
+        $course->load(['category', 'trainer.user', 'trainees', 'course_videos', 'course_keypoints', 'modules']);
+
         $user = Auth::user();
         if ($user->hasRole('trainer') && $course->trainer->user_id !== $user->id) {
             abort(403);

--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -46,6 +46,8 @@ class FrontController extends Controller
      */
     public function details(Course $course)
     {
+        $course->load(['category', 'trainer.user', 'trainees', 'course_videos', 'course_keypoints', 'modules']);
+
         return view('front.details', compact('course'));
     }
 
@@ -75,6 +77,8 @@ class FrontController extends Controller
      */
     public function learning(Course $course, $courseVideoId)
     {
+        $course->load(['category', 'trainer.user', 'trainees', 'course_videos', 'course_keypoints', 'modules']);
+
         $user = Auth::user();
 
         // Cek apakah user punya akses ke course ini

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -50,6 +50,11 @@ class Course extends Model
         return $this->hasMany(CourseKeypoint::class);
     }
 
+    public function modules()
+    {
+        return $this->hasMany(CourseModule::class);
+    }
+
     // App\Models\Course.php
 
 public function trainees()


### PR DESCRIPTION
## Summary
- define `modules()` relationship on `Course`
- eager load related models (including modules) when loading courses

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684667ec8f388321ae610819e2f73dad