### PR TITLE
Add module support for course videos

### DIFF
--- a/app/Http/Controllers/CourseVideoController.php
+++ b/app/Http/Controllers/CourseVideoController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreCourseVideoRequest;
 use App\Models\Course;
-use App\Models\CourseVideo;
+use App\Models\{CourseVideo, CourseModule};
 use Illuminate\Support\Facades\DB;
 use Illuminate\Http\Request;
 
@@ -23,8 +23,9 @@ class CourseVideoController extends Controller
      */
     public function create(Course $course)
     {
-        //
-        return view('admin.course_videos.create', compact('course'));
+        $modules = CourseModule::where('course_id', $course->id)->get();
+
+        return view('admin.course_videos.create', compact('course', 'modules'));
 
     }
 
@@ -61,8 +62,9 @@ class CourseVideoController extends Controller
      */
     public function edit(CourseVideo $courseVideo)
     {
-        //
-        return view('admin.course_videos.edit', compact('courseVideo'));
+        $modules = CourseModule::where('course_id', $courseVideo->course_id)->get();
+
+        return view('admin.course_videos.edit', compact('courseVideo', 'modules'));
 
     }
 

--- a/app/Http/Requests/StoreCourseVideoRequest.php
+++ b/app/Http/Requests/StoreCourseVideoRequest.php
@@ -22,9 +22,10 @@ class StoreCourseVideoRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'course_module_id' => 'required|exists:course_modules,id',
             'name' => 'required|string|max:255',
             'path_video' => 'required|string|max:255',
+            'order' => 'nullable|integer',
         ];
     }
 }

--- a/app/Models/CourseVideo.php
+++ b/app/Models/CourseVideo.php
@@ -13,10 +13,17 @@ class CourseVideo extends Model
     protected $fillable = [
         'name',
         'path_video',
-        'course_id'
+        'course_id',
+        'course_module_id',
+        'order',
     ];
 
     public function course(){
         return $this->belongsTo(Course::class);
+    }
+
+    public function module()
+    {
+        return $this->belongsTo(CourseModule::class, 'course_module_id');
     }
 }

--- a/database/migrations/2025_08_03_000002_add_course_module_id_and_order_to_course_videos_table.php
+++ b/database/migrations/2025_08_03_000002_add_course_module_id_and_order_to_course_videos_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('course_videos', function (Blueprint $table) {
+            $table->foreignId('course_module_id')->after('course_id')->constrained()->onDelete('cascade');
+            $table->unsignedInteger('order')->default(0)->after('course_module_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('course_videos', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('course_module_id');
+            $table->dropColumn('order');
+        });
+    }
+};

--- a/resources/views/admin/course_videos/create.blade.php
+++ b/resources/views/admin/course_videos/create.blade.php
@@ -48,6 +48,22 @@
                         <x-input-error :messages="$errors->get('path_video')" class="mt-2" />
                     </div>
 
+                    <div class="mt-4">
+                        <x-input-label for="course_module_id" :value="__('Module')" />
+                        <select id="course_module_id" name="course_module_id" class="block mt-1 w-full">
+                            @foreach($modules as $module)
+                                <option value="{{ $module->id }}" {{ old('course_module_id') == $module->id ? 'selected' : '' }}>{{ $module->name }}</option>
+                            @endforeach
+                        </select>
+                        <x-input-error :messages="$errors->get('course_module_id')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-input-label for="order" :value="__('Order')" />
+                        <x-text-input id="order" class="block mt-1 w-full" type="number" name="order" :value="old('order', 0)" />
+                        <x-input-error :messages="$errors->get('order')" class="mt-2" />
+                    </div>
+
                     <div class="flex items-center justify-end mt-4">
             
                         <button type="submit" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">

--- a/resources/views/admin/course_videos/edit.blade.php
+++ b/resources/views/admin/course_videos/edit.blade.php
@@ -49,6 +49,22 @@
                         <x-input-error :messages="$errors->get('path_video')" class="mt-2" />
                     </div>
 
+                    <div class="mt-4">
+                        <x-input-label for="course_module_id" :value="__('Module')" />
+                        <select id="course_module_id" name="course_module_id" class="block mt-1 w-full">
+                            @foreach($modules as $module)
+                                <option value="{{ $module->id }}" {{ $courseVideo->course_module_id == $module->id ? 'selected' : '' }}>{{ $module->name }}</option>
+                            @endforeach
+                        </select>
+                        <x-input-error :messages="$errors->get('course_module_id')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-input-label for="order" :value="__('Order')" />
+                        <x-text-input id="order" class="block mt-1 w-full" type="number" name="order" :value="$courseVideo->order" />
+                        <x-input-error :messages="$errors->get('order')" class="mt-2" />
+                    </div>
+
                     <div class="flex items-center justify-end mt-4">
             
                         <button type="submit" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">


### PR DESCRIPTION
## Summary
- allow videos to belong to a course module
- validate course module in video form
- show module fields in video views
- load modules in controller
- add migration for course_module_id and order columns

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684667ee2738832195be07c1bdaecef7