### PR TITLE
Implement admin curriculum management

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -177,6 +177,7 @@ class CourseController extends Controller
 
     public function show(Course $course)
     {
+        $course->load(['modules.videos', 'modules.materials', 'modules.tasks', 'course_videos']);
         return view('admin.courses.show', compact('course'));
     }
 

--- a/app/Http/Controllers/CourseModuleController.php
+++ b/app/Http/Controllers/CourseModuleController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCourseModuleRequest;
+use App\Http\Requests\UpdateCourseModuleRequest;
+use App\Models\Course;
+use App\Models\CourseModule;
+use Illuminate\Support\Facades\DB;
+
+class CourseModuleController extends Controller
+{
+    public function index(Course $course)
+    {
+        $modules = $course->modules()->with(['videos','materials','tasks'])->orderBy('order')->get();
+        return view('admin.curriculum.index', compact('course','modules'));
+    }
+
+    public function store(StoreCourseModuleRequest $request, Course $course)
+    {
+        DB::transaction(function () use ($request, $course) {
+            $data = $request->validated();
+            $data['course_id'] = $course->id;
+            $data['order'] = $data['order'] ?? ($course->modules()->max('order') + 1);
+            CourseModule::create($data);
+        });
+        return redirect()->route('admin.curriculum.index', $course);
+    }
+
+    public function update(UpdateCourseModuleRequest $request, CourseModule $courseModule)
+    {
+        DB::transaction(function () use ($request, $courseModule) {
+            $courseModule->update($request->validated());
+        });
+        return back();
+    }
+
+    public function destroy(CourseModule $courseModule)
+    {
+        $course = $courseModule->course;
+        $courseModule->delete();
+        return redirect()->route('admin.curriculum.index', $course);
+    }
+}

--- a/app/Http/Controllers/ModuleMaterialController.php
+++ b/app/Http/Controllers/ModuleMaterialController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCourseMaterialRequest;
+use App\Models\CourseModule;
+use App\Models\CourseMaterial;
+use Illuminate\Support\Facades\DB;
+
+class ModuleMaterialController extends Controller
+{
+    public function store(StoreCourseMaterialRequest $request, CourseModule $courseModule)
+    {
+        DB::transaction(function () use ($request, $courseModule) {
+            $validated = $request->validated();
+            $path = $request->file('file')->store('materials', 'public');
+            $validated['file_path'] = $path;
+            $validated['file_type'] = $request->file('file')->getClientOriginalExtension();
+            $validated['course_module_id'] = $courseModule->id;
+            CourseMaterial::create($validated);
+        });
+        return back()->with('success', 'Material uploaded successfully.');
+    }
+}

--- a/app/Http/Controllers/ModuleTaskController.php
+++ b/app/Http/Controllers/ModuleTaskController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreModuleTaskRequest;
+use App\Models\CourseModule;
+use App\Models\ModuleTask;
+use Illuminate\Support\Facades\DB;
+
+class ModuleTaskController extends Controller
+{
+    public function store(StoreModuleTaskRequest $request, CourseModule $courseModule)
+    {
+        DB::transaction(function () use ($request, $courseModule) {
+            $data = $request->validated();
+            $data['course_module_id'] = $courseModule->id;
+            ModuleTask::create($data);
+        });
+        return back();
+    }
+}

--- a/app/Http/Controllers/ModuleVideoController.php
+++ b/app/Http/Controllers/ModuleVideoController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCourseVideoRequest;
+use App\Models\CourseModule;
+use App\Models\CourseVideo;
+use Illuminate\Support\Facades\DB;
+
+class ModuleVideoController extends Controller
+{
+    public function store(StoreCourseVideoRequest $request, CourseModule $courseModule)
+    {
+        DB::transaction(function () use ($request, $courseModule) {
+            $data = $request->validated();
+            $data['course_id'] = $courseModule->course_id;
+            $data['course_module_id'] = $courseModule->id;
+            CourseVideo::create($data);
+        });
+        return back();
+    }
+}

--- a/app/Http/Requests/StoreCourseModuleRequest.php
+++ b/app/Http/Requests/StoreCourseModuleRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCourseModuleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->hasAnyRole(['admin','trainer']);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'order' => 'nullable|integer|min:0',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreModuleTaskRequest.php
+++ b/app/Http/Requests/StoreModuleTaskRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreModuleTaskRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->hasAnyRole(['admin','trainer']);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'course_module_id' => 'required|exists:course_modules,id',
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'order' => 'nullable|integer|min:0',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCourseModuleRequest.php
+++ b/app/Http/Requests/UpdateCourseModuleRequest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Http\Requests;
+
+class UpdateCourseModuleRequest extends StoreCourseModuleRequest
+{
+}

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\Certificate;
+use App\Models\CourseModule;
 
 class Course extends Model
 {
@@ -44,6 +45,11 @@ class Course extends Model
 
     public function course_videos(){
         return $this->hasMany(CourseVideo::class);
+    }
+
+    public function modules()
+    {
+        return $this->hasMany(CourseModule::class)->orderBy('order');
     }
 
     public function course_keypoints(){

--- a/app/Models/CourseModule.php
+++ b/app/Models/CourseModule.php
@@ -4,6 +4,10 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Course;
+use App\Models\CourseVideo;
+use App\Models\CourseMaterial;
+use App\Models\ModuleTask;
 
 class CourseModule extends Model
 {
@@ -15,8 +19,23 @@ class CourseModule extends Model
         'order',
     ];
 
+    public function course()
+    {
+        return $this->belongsTo(Course::class);
+    }
+
+    public function videos()
+    {
+        return $this->hasMany(CourseVideo::class);
+    }
+
     public function materials()
     {
         return $this->hasMany(CourseMaterial::class);
+    }
+
+    public function tasks()
+    {
+        return $this->hasMany(ModuleTask::class);
     }
 }

--- a/app/Models/CourseVideo.php
+++ b/app/Models/CourseVideo.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Models\Course;
+use App\Models\CourseModule;
 
 class CourseVideo extends Model
 {
@@ -13,10 +15,16 @@ class CourseVideo extends Model
     protected $fillable = [
         'name',
         'path_video',
-        'course_id'
+        'course_id',
+        'course_module_id'
     ];
 
     public function course(){
         return $this->belongsTo(Course::class);
+    }
+
+    public function module()
+    {
+        return $this->belongsTo(CourseModule::class, 'course_module_id');
     }
 }

--- a/app/Models/ModuleTask.php
+++ b/app/Models/ModuleTask.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ModuleTask extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'course_module_id',
+        'name',
+        'description',
+        'order',
+    ];
+
+    public function module()
+    {
+        return $this->belongsTo(CourseModule::class, 'course_module_id');
+    }
+}

--- a/database/migrations/2025_08_03_000005_create_module_tasks_table.php
+++ b/database/migrations/2025_08_03_000005_create_module_tasks_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('module_tasks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_module_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->unsignedInteger('order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('module_tasks');
+    }
+};

--- a/database/migrations/2025_08_03_000006_add_course_module_id_to_course_videos_table.php
+++ b/database/migrations/2025_08_03_000006_add_course_module_id_to_course_videos_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('course_videos', function (Blueprint $table) {
+            $table->foreignId('course_module_id')->nullable()->after('course_id')->constrained()->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('course_videos', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('course_module_id');
+        });
+    }
+};

--- a/resources/views/admin/courses/show.blade.php
+++ b/resources/views/admin/courses/show.blade.php
@@ -79,6 +79,46 @@
                 </div>
                 @empty
                 @endforelse
+
+                <hr class="my-5">
+
+                <div class="flex flex-row justify-between items-center mb-4">
+                    <div class="flex flex-col">
+                        <h3 class="text-indigo-950 text-xl font-bold">Modules</h3>
+                        <p class="text-slate-500 text-sm">{{ $course->modules->count() }}</p>
+                    </div>
+                    <a href="{{ route('admin.curriculum.index', $course) }}" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">
+                        Manage Curriculum
+                    </a>
+                </div>
+
+                @foreach($course->modules as $module)
+                    <div class="border rounded p-4 mb-3">
+                        <h4 class="font-semibold">{{ $module->name }} <span class="text-sm text-gray-500">(Order: {{ $module->order }})</span></h4>
+                        <div class="ml-4 mt-2">
+                            <h5 class="font-semibold">Videos</h5>
+                            <ul class="list-disc list-inside">
+                                @foreach($module->videos as $v)
+                                    <li>{{ $v->name }}</li>
+                                @endforeach
+                            </ul>
+
+                            <h5 class="font-semibold mt-2">Materials</h5>
+                            <ul class="list-disc list-inside">
+                                @foreach($module->materials as $m)
+                                    <li>{{ $m->name }}</li>
+                                @endforeach
+                            </ul>
+
+                            <h5 class="font-semibold mt-2">Tasks</h5>
+                            <ul class="list-disc list-inside">
+                                @foreach($module->tasks as $t)
+                                    <li>{{ $t->name }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    </div>
+                @endforeach
                 
             </div>
         </div>

--- a/resources/views/admin/curriculum/index.blade.php
+++ b/resources/views/admin/curriculum/index.blade.php
@@ -1,0 +1,87 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Manage Curriculum') }}</h2>
+            <a href="{{ route('admin.courses.show', $course) }}" class="font-bold py-2 px-4 bg-gray-700 text-white rounded-full">Back</a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('admin.curriculum.store', $course) }}" class="mb-4 flex gap-2">
+                    @csrf
+                    <input type="text" name="name" class="border rounded w-full" placeholder="Module name">
+                    <input type="number" name="order" class="border rounded w-24" placeholder="Order">
+                    <button class="px-4 py-2 bg-indigo-700 text-white rounded">Add Module</button>
+                </form>
+
+                @foreach($modules as $module)
+                    <div class="border p-4 rounded mb-4">
+                        <div class="flex justify-between items-center mb-2">
+                            <form method="POST" action="{{ route('admin.curriculum.update', $module) }}" class="flex flex-1 gap-2">
+                                @csrf
+                                @method('PUT')
+                                <input type="text" name="name" value="{{ $module->name }}" class="border rounded w-full">
+                                <input type="number" name="order" value="{{ $module->order }}" class="border rounded w-24">
+                                <button class="px-3 py-1 bg-indigo-700 text-white rounded">Save</button>
+                            </form>
+                            <form method="POST" action="{{ route('admin.curriculum.destroy', $module) }}">
+                                @csrf
+                                @method('DELETE')
+                                <button class="px-3 py-1 bg-red-700 text-white rounded">Delete</button>
+                            </form>
+                        </div>
+
+                        <div class="ml-4">
+                            <form method="POST" action="{{ route('admin.curriculum.videos.store', $module) }}" class="flex gap-2 mb-2">
+                                @csrf
+                                <input type="text" name="name" placeholder="Video name" class="border rounded w-full">
+                                <input type="text" name="path_video" placeholder="YouTube ID" class="border rounded w-full">
+                                <button class="px-3 py-1 bg-green-700 text-white rounded">Add Video</button>
+                            </form>
+
+                            <form method="POST" action="{{ route('admin.curriculum.materials.store', $module) }}" enctype="multipart/form-data" class="flex gap-2 mb-2">
+                                @csrf
+                                <input type="hidden" name="course_module_id" value="{{ $module->id }}">
+                                <input type="text" name="name" placeholder="Material name" class="border rounded w-full">
+                                <input type="file" name="file" class="border rounded w-full">
+                                <button class="px-3 py-1 bg-green-700 text-white rounded">Add Material</button>
+                            </form>
+
+                            <form method="POST" action="{{ route('admin.curriculum.tasks.store', $module) }}" class="flex gap-2 mb-2">
+                                @csrf
+                                <input type="hidden" name="course_module_id" value="{{ $module->id }}">
+                                <input type="text" name="name" placeholder="Task name" class="border rounded w-full">
+                                <input type="text" name="description" placeholder="Description" class="border rounded w-full">
+                                <input type="number" name="order" placeholder="Order" class="border rounded w-24">
+                                <button class="px-3 py-1 bg-green-700 text-white rounded">Add Task</button>
+                            </form>
+
+                            <div class="mt-2">
+                                <h4 class="font-semibold">Videos</h4>
+                                <ul class="list-disc list-inside">
+                                    @foreach($module->videos as $v)
+                                        <li>{{ $v->name }}</li>
+                                    @endforeach
+                                </ul>
+                                <h4 class="font-semibold mt-2">Materials</h4>
+                                <ul class="list-disc list-inside">
+                                    @foreach($module->materials as $m)
+                                        <li>{{ $m->name }}</li>
+                                    @endforeach
+                                </ul>
+                                <h4 class="font-semibold mt-2">Tasks</h4>
+                                <ul class="list-disc list-inside">
+                                    @foreach($module->tasks as $t)
+                                        <li>{{ $t->name }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,10 @@ use App\Http\Controllers\{
     CourseController,
     CourseVideoController,
     CourseMaterialController,
+    CourseModuleController,
+    ModuleVideoController,
+    ModuleMaterialController,
+    ModuleTaskController,
     SubscribeTransactionController,
     TrainerController,
     FinalQuizController,
@@ -87,6 +91,17 @@ Route::middleware('auth')->group(function () {
             Route::post('/add/video/save/{course:id}', [CourseVideoController::class, 'store'])->name('course.add_video.save');
 
             Route::post('course-materials', [CourseMaterialController::class, 'store'])->name('course_materials.store');
+
+            Route::prefix('curriculum')->name('curriculum.')->group(function () {
+                Route::get('course/{course}', [CourseModuleController::class, 'index'])->name('index');
+                Route::post('course/{course}', [CourseModuleController::class, 'store'])->name('store');
+                Route::put('module/{courseModule}', [CourseModuleController::class, 'update'])->name('update');
+                Route::delete('module/{courseModule}', [CourseModuleController::class, 'destroy'])->name('destroy');
+
+                Route::post('module/{courseModule}/videos', [ModuleVideoController::class, 'store'])->name('videos.store');
+                Route::post('module/{courseModule}/materials', [ModuleMaterialController::class, 'store'])->name('materials.store');
+                Route::post('module/{courseModule}/tasks', [ModuleTaskController::class, 'store'])->name('tasks.store');
+            });
 
           // Final Quiz Management Routes
           Route::get('course-quiz', [FinalQuizController::class, 'index'])->name('course_quiz.index');


### PR DESCRIPTION
## Summary
- add controllers and requests to manage course modules, videos, materials and tasks
- define `ModuleTask` model and migrations
- extend existing models with curriculum relations
- add curriculum routes for admins and trainers
- show modules and nested items on course detail page
- provide curriculum management view

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684667ef90ec8321b7fdc4da18098212