### PR TITLE
Add CourseModule & Task routes

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -20,6 +20,12 @@
                     <x-nav-link :href="route('admin.courses.index')" :active="request()->routeIs('admin.courses.index')">
                         {{ __('Manage Courses') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('admin.course_modules.index')" :active="request()->routeIs('admin.course_modules.index')">
+                        {{ __('Manage Modules') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('admin.tasks.index')" :active="request()->routeIs('admin.tasks.index')">
+                        {{ __('Manage Tasks') }}
+                    </x-nav-link>
                     @endrole
 
                     @role('admin')

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,8 @@ use App\Http\Controllers\{
     FinalQuizController,
     QuizAttemptController, // Pastikan ini sudah ada
     CertificateController,
+    CourseModuleController,
+    TaskController,
     TalentAdminController,
     TalentController,
     RecruiterController,
@@ -82,6 +84,8 @@ Route::middleware('auth')->group(function () {
         Route::middleware('role:admin|trainer')->group(function () {
             Route::resource('courses', CourseController::class);
             Route::resource('course_videos', CourseVideoController::class);
+            Route::resource('course_modules', CourseModuleController::class);
+            Route::resource('tasks', TaskController::class);
 
             Route::get('/add/video/{course:id}', [CourseVideoController::class, 'create'])->name('course.add_video');
             Route::post('/add/video/save/{course:id}', [CourseVideoController::class, 'store'])->name('course.add_video.save');


### PR DESCRIPTION
## Summary
- add admin resource routes for CourseModule and Task
- show new links in navigation

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684667f222c48321815349ba2aa17bb7