### PR TITLE
Add curriculum structure tests

### DIFF
--- a/database/factories/CourseMaterialFactory.php
+++ b/database/factories/CourseMaterialFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\CourseModule;
+
+class CourseMaterialFactory extends Factory
+{
+    protected $model = \App\Models\CourseMaterial::class;
+
+    public function definition(): array
+    {
+        return [
+            'course_module_id' => CourseModule::factory(),
+            'name' => $this->faker->sentence(2),
+            'file_path' => 'materials/sample.pdf',
+            'file_type' => 'pdf',
+            'order' => 0,
+        ];
+    }
+}

--- a/database/factories/CourseModuleFactory.php
+++ b/database/factories/CourseModuleFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Course;
+
+class CourseModuleFactory extends Factory
+{
+    protected $model = \App\Models\CourseModule::class;
+
+    public function definition(): array
+    {
+        return [
+            'course_id' => Course::factory(),
+            'name' => $this->faker->sentence(3),
+            'order' => 0,
+        ];
+    }
+}

--- a/database/migrations/2025_08_01_020000_create_course_modules_table.php
+++ b/database/migrations/2025_08_01_020000_create_course_modules_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('course_modules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->unsignedInteger('order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('course_modules');
+    }
+};

--- a/tests/Feature/CurriculumStructureTest.php
+++ b/tests/Feature/CurriculumStructureTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{Course, CourseModule, CourseVideo, CourseMaterial, User, SubscribeTransaction, CourseProgress};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class CurriculumStructureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::firstOrCreate(['name' => 'trainee']);
+    }
+
+    public function test_modules_videos_and_materials_can_be_created_and_ordered(): void
+    {
+        $course = Course::factory()->create();
+
+        $moduleA = CourseModule::factory()->create(['course_id' => $course->id, 'order' => 2]);
+        $moduleB = CourseModule::factory()->create(['course_id' => $course->id, 'order' => 1]);
+
+        $video1 = CourseVideo::factory()->create(['course_id' => $course->id]);
+        $video2 = CourseVideo::factory()->create(['course_id' => $course->id]);
+
+        $material1 = CourseMaterial::factory()->create(['course_module_id' => $moduleB->id, 'order' => 2]);
+        $material2 = CourseMaterial::factory()->create(['course_module_id' => $moduleB->id, 'order' => 1]);
+
+        $orderedModules = CourseModule::where('course_id', $course->id)->orderBy('order')->pluck('id')->toArray();
+        $this->assertSame([$moduleB->id, $moduleA->id], $orderedModules);
+
+        $orderedMaterials = $moduleB->materials()->orderBy('order')->pluck('id')->toArray();
+        $this->assertSame([$material2->id, $material1->id], $orderedMaterials);
+    }
+
+    public function test_learner_access_and_progress_tracking(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('trainee');
+
+        $course = Course::factory()->create(['price' => 100]);
+        $videos = CourseVideo::factory()->count(2)->create(['course_id' => $course->id]);
+
+        SubscribeTransaction::create([
+            'total_amount' => 100,
+            'is_paid' => true,
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+            'proof' => 'proof.png',
+            'subscription_start_date' => now(),
+        ]);
+
+        $this->actingAs($user)->get(route('front.learning', [$course->id, $videos[0]->id]))->assertStatus(200);
+        $progress = CourseProgress::where('user_id', $user->id)->where('course_id', $course->id)->first();
+        $this->assertNotNull($progress);
+        $this->assertEquals(50, $progress->progress);
+        $this->assertCount(1, $progress->completed_videos);
+
+        $this->actingAs($user)->get(route('front.learning', [$course->id, $videos[1]->id]))->assertStatus(200);
+        $progress->refresh();
+        $this->assertEquals(100, $progress->progress);
+        $this->assertCount(2, $progress->completed_videos);
+    }
+
+    public function test_learner_without_access_is_redirected(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('trainee');
+
+        $course = Course::factory()->create(['price' => 100]);
+        $video = CourseVideo::factory()->create(['course_id' => $course->id]);
+
+        $response = $this->actingAs($user)->get(route('front.learning', [$course->id, $video->id]));
+        $response->assertRedirect(route('front.pricing', ['course' => $course->slug]));
+    }
+}


### PR DESCRIPTION
## Summary
- add migration for course modules
- add factories for course modules and materials
- add feature tests for creating modules, videos, materials, and learner progress

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684667f33f288321bf6b594b6fda6c3d