### PR TITLE
Add drag-and-drop sorting for curriculum modules

### DIFF
--- a/app/Http/Controllers/CourseModuleController.php
+++ b/app/Http/Controllers/CourseModuleController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\UpdateCourseModuleRequest;
 use App\Models\Course;
 use App\Models\CourseModule;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Http\Request;
 
 class CourseModuleController extends Controller
 {
@@ -40,5 +41,16 @@ class CourseModuleController extends Controller
         $course = $courseModule->course;
         $courseModule->delete();
         return redirect()->route('admin.curriculum.index', $course);
+    }
+
+    public function reorder(Request $request, Course $course)
+    {
+        $request->validate(['modules' => 'required|array']);
+        DB::transaction(function () use ($request) {
+            foreach ($request->modules as $index => $id) {
+                CourseModule::where('id', $id)->update(['order' => $index + 1]);
+            }
+        });
+        return response()->json(['status' => 'ok']);
     }
 }

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -44,7 +44,7 @@ class Course extends Model
     }
 
     public function course_videos(){
-        return $this->hasMany(CourseVideo::class);
+        return $this->hasMany(CourseVideo::class)->orderBy('order');
     }
 
     public function course_keypoints(){
@@ -53,7 +53,7 @@ class Course extends Model
 
     public function modules()
     {
-        return $this->hasMany(CourseModule::class);
+        return $this->hasMany(CourseModule::class)->orderBy('order');
     }
 
     // App\Models\Course.php

--- a/app/Models/CourseModule.php
+++ b/app/Models/CourseModule.php
@@ -26,16 +26,16 @@ class CourseModule extends Model
 
     public function videos()
     {
-        return $this->hasMany(CourseVideo::class);
+        return $this->hasMany(CourseVideo::class)->orderBy('order');
     }
 
     public function materials()
     {
-        return $this->hasMany(CourseMaterial::class);
+        return $this->hasMany(CourseMaterial::class)->orderBy('order');
     }
 
     public function tasks()
     {
-        return $this->hasMany(ModuleTask::class);
+        return $this->hasMany(ModuleTask::class)->orderBy('order');
     }
 }

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -20,12 +20,7 @@
                     <x-nav-link :href="route('admin.courses.index')" :active="request()->routeIs('admin.courses.index')">
                         {{ __('Manage Courses') }}
                     </x-nav-link>
-                    <x-nav-link :href="route('admin.course_modules.index')" :active="request()->routeIs('admin.course_modules.index')">
-                        {{ __('Manage Modules') }}
-                    </x-nav-link>
-                    <x-nav-link :href="route('admin.tasks.index')" :active="request()->routeIs('admin.tasks.index')">
-                        {{ __('Manage Tasks') }}
-                    </x-nav-link>
+                    {{-- Module and Task management removed per request --}}
                     @endrole
 
                     @role('admin')

--- a/routes/web.php
+++ b/routes/web.php
@@ -104,6 +104,10 @@ Route::middleware('auth')->group(function () {
                 Route::post('module/{courseModule}/videos', [ModuleVideoController::class, 'store'])->name('videos.store');
                 Route::post('module/{courseModule}/materials', [ModuleMaterialController::class, 'store'])->name('materials.store');
                 Route::post('module/{courseModule}/tasks', [ModuleTaskController::class, 'store'])->name('tasks.store');
+                Route::post('course/{course}/modules/reorder', [CourseModuleController::class, 'reorder'])->name('modules.reorder');
+                Route::post('module/{courseModule}/videos/reorder', [ModuleVideoController::class, 'reorder'])->name('videos.reorder');
+                Route::post('module/{courseModule}/materials/reorder', [ModuleMaterialController::class, 'reorder'])->name('materials.reorder');
+                Route::post('module/{courseModule}/tasks/reorder', [ModuleTaskController::class, 'reorder'])->name('tasks.reorder');
             });
 
           // Final Quiz Management Routes


### PR DESCRIPTION
## Summary
- remove module/task management links from nav
- order modules and their content automatically
- add API endpoints for reordering modules, videos, materials, and tasks
- allow curriculum items to be reordered via Sortable.js

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a9bab4d88321b6836f2c3e7cce24