### PR TITLE
Add manual completion tracking for course items

### DIFF
--- a/app/Models/CourseProgress.php
+++ b/app/Models/CourseProgress.php
@@ -15,12 +15,16 @@ class CourseProgress extends Model
         'user_id',
         'course_id',
         'completed_videos',
+        'completed_materials',
+        'completed_tasks',
         'quiz_passed',
         'progress',
     ];
 
     protected $casts = [
         'completed_videos' => 'array',
+        'completed_materials' => 'array',
+        'completed_tasks' => 'array',
         'quiz_passed' => 'boolean',
     ];
 

--- a/database/factories/ModuleTaskFactory.php
+++ b/database/factories/ModuleTaskFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\CourseModule;
+
+class ModuleTaskFactory extends Factory
+{
+    protected $model = \App\Models\ModuleTask::class;
+
+    public function definition(): array
+    {
+        return [
+            'course_module_id' => CourseModule::factory(),
+            'name' => $this->faker->sentence(2),
+            'description' => $this->faker->sentence(6),
+            'order' => 0,
+        ];
+    }
+}

--- a/database/migrations/2025_08_04_000010_add_materials_tasks_to_course_progresses_table.php
+++ b/database/migrations/2025_08_04_000010_add_materials_tasks_to_course_progresses_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('course_progresses', function (Blueprint $table) {
+            $table->json('completed_materials')->nullable()->after('completed_videos');
+            $table->json('completed_tasks')->nullable()->after('completed_materials');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('course_progresses', function (Blueprint $table) {
+            $table->dropColumn(['completed_materials', 'completed_tasks']);
+        });
+    }
+};

--- a/resources/views/front/learning.blade.php
+++ b/resources/views/front/learning.blade.php
@@ -52,14 +52,21 @@
                                     @endphp
 
                                     @if($hasAccess || $course->price == 0)
-                                        <a href="{{ route('front.learning', [$course, 'courseVideoId' => $video->id]) }}" class="group p-[12px_16px] flex items-center gap-[10px] rounded-full transition-all duration-300 {{ $isActive ? 'bg-[#3525B3] active-video' : 'bg-[#E9EFF3] hover:bg-[#3525B3]' }}">
-                                            <div class="text-black group-hover:text-white {{ $isActive ? 'text-white' : '' }}">
-                                                ▶️
-                                            </div>
-                                            <p class="font-semibold {{ $isActive ? 'text-white' : 'group-hover:text-white text-black' }}">
-                                                {{ $video->name }}
-                                            </p>
-                                        </a>
+                                        <div class="flex items-center gap-2">
+                                            <a href="{{ route('front.learning', [$course, 'courseVideoId' => $video->id]) }}" class="flex-1 group p-[12px_16px] flex items-center gap-[10px] rounded-full transition-all duration-300 {{ $isActive ? 'bg-[#3525B3] active-video' : 'bg-[#E9EFF3] hover:bg-[#3525B3]' }}">
+                                                <div class="text-black group-hover:text-white {{ $isActive ? 'text-white' : '' }}">▶️</div>
+                                                <p class="font-semibold {{ $isActive ? 'text-white' : 'group-hover:text-white text-black' }}">{{ $video->name }}</p>
+                                            </a>
+                                            @if(in_array($video->id, $progress->completed_videos ?? []))
+                                                <span class="text-green-600">✔</span>
+                                            @else
+                                                <form method="POST" action="{{ route('learning.item.complete', [$course, $video->id]) }}">
+                                                    @csrf
+                                                    <input type="hidden" name="type" value="video">
+                                                    <button type="submit" class="text-xs text-blue-500">Mark as done</button>
+                                                </form>
+                                            @endif
+                                        </div>
                                     @else
                                         <div class="group p-[12px_16px] flex items-center gap-[10px] bg-[#E9EFF3] rounded-full opacity-50 cursor-not-allowed">
                                             <div class="text-black">🔒</div>
@@ -69,16 +76,38 @@
                                 @endforeach
 
                                 @foreach($module->materials as $material)
-                                    <a href="{{ Storage::url($material->file_path) }}" class="group p-[12px_16px] flex items-center gap-[10px] bg-[#E9EFF3] rounded-full hover:bg-[#3525B3] transition-all">
-                                        <div class="text-black group-hover:text-white">📄</div>
-                                        <p class="font-semibold group-hover:text-white">{{ $material->name }}</p>
-                                    </a>
+                                    <div class="flex items-center gap-2">
+                                        <a href="{{ Storage::url($material->file_path) }}" class="flex-1 group p-[12px_16px] flex items-center gap-[10px] bg-[#E9EFF3] rounded-full hover:bg-[#3525B3] transition-all">
+                                            <div class="text-black group-hover:text-white">📄</div>
+                                            <p class="font-semibold group-hover:text-white">{{ $material->name }}</p>
+                                        </a>
+                                        @if(in_array($material->id, $progress->completed_materials ?? []))
+                                            <span class="text-green-600">✔</span>
+                                        @else
+                                            <form method="POST" action="{{ route('learning.item.complete', [$course, $material->id]) }}">
+                                                @csrf
+                                                <input type="hidden" name="type" value="material">
+                                                <button type="submit" class="text-xs text-blue-500">Mark as done</button>
+                                            </form>
+                                        @endif
+                                    </div>
                                 @endforeach
 
                                 @foreach($module->tasks as $task)
-                                    <div class="group p-[12px_16px] flex items-center gap-[10px] bg-[#E9EFF3] rounded-full">
-                                        <div class="text-black">📝</div>
-                                        <p class="font-semibold text-black">{{ $task->name }}</p>
+                                    <div class="flex items-center gap-2">
+                                        <div class="group p-[12px_16px] flex items-center gap-[10px] bg-[#E9EFF3] rounded-full">
+                                            <div class="text-black">📝</div>
+                                            <p class="font-semibold text-black">{{ $task->name }}</p>
+                                        </div>
+                                        @if(in_array($task->id, $progress->completed_tasks ?? []))
+                                            <span class="text-green-600">✔</span>
+                                        @else
+                                            <form method="POST" action="{{ route('learning.item.complete', [$course, $task->id]) }}">
+                                                @csrf
+                                                <input type="hidden" name="type" value="task">
+                                                <button type="submit" class="text-xs text-blue-500">Mark as done</button>
+                                            </form>
+                                        @endif
                                     </div>
                                 @endforeach
                             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,10 @@ Route::middleware('auth')->group(function () {
         ->name('front.learning')
         ->middleware('role:trainee|trainer|admin');
 
+    Route::post('/learning/{course}/{item}/complete', [FrontController::class, 'markItemComplete'])
+        ->name('learning.item.complete')
+        ->middleware('role:trainee');
+
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
     // ====================


### PR DESCRIPTION
## Summary
- extend `course_progresses` table with materials and tasks completion
- track completed materials and tasks in `CourseProgress` model
- update learning view with controls to mark videos, materials, and tasks done
- add route and controller method to record completion and recalc progress
- create factory for module tasks
- revise curriculum test for new completion flow

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474a7d6cf88321a3a7e0887d10cf32