### PR TITLE
Add curriculum item creation pages

### DIFF
--- a/app/Http/Controllers/ModuleMaterialController.php
+++ b/app/Http/Controllers/ModuleMaterialController.php
@@ -10,6 +10,11 @@ use Illuminate\Http\Request;
 
 class ModuleMaterialController extends Controller
 {
+    public function create(CourseModule $courseModule)
+    {
+        return view('admin.curriculum.materials.create', compact('courseModule'));
+    }
+
     public function store(StoreCourseMaterialRequest $request, CourseModule $courseModule)
     {
         DB::transaction(function () use ($request, $courseModule) {

--- a/app/Http/Controllers/ModuleTaskController.php
+++ b/app/Http/Controllers/ModuleTaskController.php
@@ -10,6 +10,11 @@ use Illuminate\Http\Request;
 
 class ModuleTaskController extends Controller
 {
+    public function create(CourseModule $courseModule)
+    {
+        return view('admin.curriculum.tasks.create', compact('courseModule'));
+    }
+
     public function store(StoreModuleTaskRequest $request, CourseModule $courseModule)
     {
         DB::transaction(function () use ($request, $courseModule) {

--- a/app/Http/Controllers/ModuleVideoController.php
+++ b/app/Http/Controllers/ModuleVideoController.php
@@ -10,6 +10,11 @@ use Illuminate\Http\Request;
 
 class ModuleVideoController extends Controller
 {
+    public function create(CourseModule $courseModule)
+    {
+        return view('admin.curriculum.videos.create', compact('courseModule'));
+    }
+
     public function store(StoreCourseVideoRequest $request, CourseModule $courseModule)
     {
         DB::transaction(function () use ($request, $courseModule) {

--- a/resources/views/admin/curriculum/index.blade.php
+++ b/resources/views/admin/curriculum/index.blade.php
@@ -33,28 +33,11 @@
                         </div>
 
                         <div class="ml-4">
-                            <form method="POST" action="{{ route('admin.curriculum.videos.store', $module) }}" class="flex gap-2 mb-2">
-                                @csrf
-                                <input type="text" name="name" placeholder="Video name" class="border rounded w-full">
-                                <input type="text" name="path_video" placeholder="YouTube ID" class="border rounded w-full">
-                                <button class="px-3 py-1 bg-green-700 text-white rounded">Add Video</button>
-                            </form>
-
-                            <form method="POST" action="{{ route('admin.curriculum.materials.store', $module) }}" enctype="multipart/form-data" class="flex gap-2 mb-2">
-                                @csrf
-                                <input type="hidden" name="course_module_id" value="{{ $module->id }}">
-                                <input type="text" name="name" placeholder="Material name" class="border rounded w-full">
-                                <input type="file" name="file" class="border rounded w-full">
-                                <button class="px-3 py-1 bg-green-700 text-white rounded">Add Material</button>
-                            </form>
-
-                            <form method="POST" action="{{ route('admin.curriculum.tasks.store', $module) }}" class="flex gap-2 mb-2">
-                                @csrf
-                                <input type="hidden" name="course_module_id" value="{{ $module->id }}">
-                                <input type="text" name="name" placeholder="Task name" class="border rounded w-full">
-                                <input type="text" name="description" placeholder="Description" class="border rounded w-full">
-                                <button class="px-3 py-1 bg-green-700 text-white rounded">Add Task</button>
-                            </form>
+                            <div class="flex gap-2 mb-2">
+                                <a href="{{ route('admin.curriculum.videos.create', $module) }}" class="px-3 py-1 bg-green-700 text-white rounded">Add Video</a>
+                                <a href="{{ route('admin.curriculum.materials.create', $module) }}" class="px-3 py-1 bg-green-700 text-white rounded">Add Material</a>
+                                <a href="{{ route('admin.curriculum.tasks.create', $module) }}" class="px-3 py-1 bg-green-700 text-white rounded">Add Task</a>
+                            </div>
 
                             <div class="mt-2">
                                 <h4 class="font-semibold">Videos</h4>

--- a/resources/views/admin/curriculum/materials/create.blade.php
+++ b/resources/views/admin/curriculum/materials/create.blade.php
@@ -1,0 +1,33 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Add Material to Module') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('admin.curriculum.materials.store', $courseModule) }}" enctype="multipart/form-data">
+                    @csrf
+                    <input type="hidden" name="course_module_id" value="{{ $courseModule->id }}">
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" required autofocus />
+                        <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                    </div>
+                    <div class="mt-4">
+                        <x-input-label for="file" :value="__('File')" />
+                        <x-text-input id="file" class="block mt-1 w-full" type="file" name="file" required />
+                        <x-input-error :messages="$errors->get('file')" class="mt-2" />
+                    </div>
+                    <div class="flex items-center justify-end mt-4">
+                        <button type="submit" class="px-4 py-2 bg-indigo-700 text-white rounded">
+                            {{ __('Add Material') }}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/curriculum/tasks/create.blade.php
+++ b/resources/views/admin/curriculum/tasks/create.blade.php
@@ -1,0 +1,33 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Add Task to Module') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('admin.curriculum.tasks.store', $courseModule) }}">
+                    @csrf
+                    <input type="hidden" name="course_module_id" value="{{ $courseModule->id }}">
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" required autofocus />
+                        <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                    </div>
+                    <div class="mt-4">
+                        <x-input-label for="description" :value="__('Description')" />
+                        <x-text-input id="description" class="block mt-1 w-full" type="text" name="description" />
+                        <x-input-error :messages="$errors->get('description')" class="mt-2" />
+                    </div>
+                    <div class="flex items-center justify-end mt-4">
+                        <button type="submit" class="px-4 py-2 bg-indigo-700 text-white rounded">
+                            {{ __('Add Task') }}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/curriculum/videos/create.blade.php
+++ b/resources/views/admin/curriculum/videos/create.blade.php
@@ -1,0 +1,33 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Add Video to Module') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('admin.curriculum.videos.store', $courseModule) }}">
+                    @csrf
+                    <input type="hidden" name="course_module_id" value="{{ $courseModule->id }}">
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" required autofocus />
+                        <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                    </div>
+                    <div class="mt-4">
+                        <x-input-label for="path_video" :value="__('YouTube ID')" />
+                        <x-text-input id="path_video" class="block mt-1 w-full" type="text" name="path_video" required />
+                        <x-input-error :messages="$errors->get('path_video')" class="mt-2" />
+                    </div>
+                    <div class="flex items-center justify-end mt-4">
+                        <button type="submit" class="px-4 py-2 bg-indigo-700 text-white rounded">
+                            {{ __('Add Video') }}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -104,6 +104,10 @@ Route::middleware('auth')->group(function () {
                 Route::delete('module/{courseModule}', [CourseModuleController::class, 'destroy'])->name('destroy');
                 Route::post('course/{course}/modules/reorder', [CourseModuleController::class, 'reorder'])->name('modules.reorder');
 
+                Route::get('module/{courseModule}/videos/create', [ModuleVideoController::class, 'create'])->name('videos.create');
+                Route::get('module/{courseModule}/materials/create', [ModuleMaterialController::class, 'create'])->name('materials.create');
+                Route::get('module/{courseModule}/tasks/create', [ModuleTaskController::class, 'create'])->name('tasks.create');
+
                 Route::post('module/{courseModule}/videos', [ModuleVideoController::class, 'store'])->name('videos.store');
                 Route::post('module/{courseModule}/materials', [ModuleMaterialController::class, 'store'])->name('materials.store');
                 Route::post('module/{courseModule}/tasks', [ModuleTaskController::class, 'store'])->name('tasks.store');


### PR DESCRIPTION
## Summary
- add `create` methods to module controllers
- create Blade views for adding videos, materials and tasks
- expose routes for the new forms
- link to forms from curriculum index instead of inline forms

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847705966648321b3b7d0e6bbbdccae