### PR TITLE
Add deadline field for module tasks

### DIFF
--- a/app/Http/Requests/StoreModuleTaskRequest.php
+++ b/app/Http/Requests/StoreModuleTaskRequest.php
@@ -18,6 +18,7 @@ class StoreModuleTaskRequest extends FormRequest
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
             'order' => 'nullable|integer|min:0',
+            'deadline' => 'nullable|date|after:today',
         ];
     }
 }

--- a/app/Models/ModuleTask.php
+++ b/app/Models/ModuleTask.php
@@ -14,6 +14,11 @@ class ModuleTask extends Model
         'name',
         'description',
         'order',
+        'deadline',
+    ];
+
+    protected $casts = [
+        'deadline' => 'datetime',
     ];
 
     public function module()

--- a/database/migrations/2025_08_04_000011_add_deadline_to_module_tasks_table.php
+++ b/database/migrations/2025_08_04_000011_add_deadline_to_module_tasks_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('module_tasks', function (Blueprint $table) {
+            $table->timestamp('deadline')->nullable()->after('order');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('module_tasks', function (Blueprint $table) {
+            $table->dropColumn('deadline');
+        });
+    }
+};

--- a/resources/views/admin/curriculum/tasks/create.blade.php
+++ b/resources/views/admin/curriculum/tasks/create.blade.php
@@ -21,6 +21,11 @@
                         <x-text-input id="description" class="block mt-1 w-full" type="text" name="description" />
                         <x-input-error :messages="$errors->get('description')" class="mt-2" />
                     </div>
+                    <div class="mt-4">
+                        <x-input-label for="deadline" :value="__('Deadline')" />
+                        <x-text-input id="deadline" class="block mt-1 w-full" type="datetime-local" name="deadline" />
+                        <x-input-error :messages="$errors->get('deadline')" class="mt-2" />
+                    </div>
                     <div class="flex items-center justify-end mt-4">
                         <button type="submit" class="px-4 py-2 bg-indigo-700 text-white rounded">
                             {{ __('Add Task') }}

--- a/resources/views/front/learning.blade.php
+++ b/resources/views/front/learning.blade.php
@@ -97,7 +97,12 @@
                                     <div class="flex items-center gap-2">
                                         <div class="group p-[12px_16px] flex items-center gap-[10px] bg-[#E9EFF3] rounded-full">
                                             <div class="text-black">📝</div>
-                                            <p class="font-semibold text-black">{{ $task->name }}</p>
+                                            <p class="font-semibold text-black">
+                                                {{ $task->name }}
+                                                @if($task->deadline)
+                                                    <span class="text-xs text-gray-500 ml-2">{{ $task->deadline->format('d M Y H:i') }}</span>
+                                                @endif
+                                            </p>
                                         </div>
                                         @if(in_array($task->id, $progress->completed_tasks ?? []))
                                             <span class="text-green-600">✔</span>


### PR DESCRIPTION
## Summary
- add migration for task deadline
- allow `deadline` field in `ModuleTask` model
- validate optional deadline when storing tasks
- include deadline input on new task form
- show task deadlines in the learning view

## Testing
- `php artisan test --testsuite=Feature` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847716f4afc8321a8388e6542b59685