### PR TITLE
Add task submission feature

### DIFF
--- a/app/Http/Controllers/TaskSubmissionController.php
+++ b/app/Http/Controllers/TaskSubmissionController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\{ModuleTask, TaskSubmission, CourseProgress, CourseVideo, CourseMaterial, ModuleTask as Task, Certificate};
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class TaskSubmissionController extends Controller
+{
+    public function create(ModuleTask $task)
+    {
+        return view('front.task_submissions.create', compact('task'));
+    }
+
+    public function store(Request $request, ModuleTask $task)
+    {
+        $user = Auth::user();
+
+        $data = $request->validate([
+            'file' => 'nullable|file',
+            'answer' => 'nullable|string',
+        ]);
+
+        if (!$request->hasFile('file') && empty($data['answer'])) {
+            return back()->withErrors('File or answer is required.');
+        }
+
+        DB::transaction(function () use ($request, $task, $user, $data) {
+            $path = null;
+            if ($request->hasFile('file')) {
+                $path = $request->file('file')->store('task_submissions', 'public');
+            }
+
+            TaskSubmission::create([
+                'module_task_id' => $task->id,
+                'user_id' => $user->id,
+                'file_path' => $path,
+                'answer' => $data['answer'] ?? null,
+            ]);
+
+            $progress = CourseProgress::firstOrCreate([
+                'user_id' => $user->id,
+                'course_id' => $task->module->course_id,
+            ], [
+                'completed_videos' => [],
+                'completed_materials' => [],
+                'completed_tasks' => [],
+                'progress' => 0,
+            ]);
+
+            $completed = $progress->completed_tasks ?? [];
+            if (!in_array($task->id, $completed)) {
+                $completed[] = $task->id;
+                $progress->completed_tasks = $completed;
+            }
+
+            $totalVideos = CourseVideo::where('course_id', $task->module->course_id)->count();
+            $totalMaterials = CourseMaterial::whereHas('module', function ($q) use ($task) {
+                $q->where('course_id', $task->module->course_id);
+            })->count();
+            $totalTasks = Task::whereHas('module', function ($q) use ($task) {
+                $q->where('course_id', $task->module->course_id);
+            })->count();
+
+            $completedCount = count($progress->completed_videos ?? []) + count($progress->completed_materials ?? []) + count($progress->completed_tasks ?? []);
+            $totalItems = $totalVideos + $totalMaterials + $totalTasks;
+            $progress->progress = $totalItems > 0 ? floor($completedCount / $totalItems * 100) : 0;
+            $progress->save();
+
+            if ($progress->progress == 100 && $progress->quiz_passed && !$progress->course->certificates()->where('user_id', $user->id)->exists()) {
+                $this->generateCertificate($progress->course, $user);
+            }
+        });
+
+        return back();
+    }
+
+    private function generateCertificate(\App\Models\Course $course, $user): void
+    {
+        $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('certificates.certificate', [
+            'course' => $course,
+            'user' => $user,
+            'date' => now()->toDateString(),
+        ]);
+
+        $path = 'certificates/' . $user->id . '_' . $course->id . '.pdf';
+        Storage::disk('public')->put($path, $pdf->output());
+
+        Certificate::create([
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+            'path' => $path,
+            'generated_at' => now(),
+        ]);
+    }
+}

--- a/app/Models/TaskSubmission.php
+++ b/app/Models/TaskSubmission.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TaskSubmission extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'module_task_id',
+        'user_id',
+        'file_path',
+        'answer',
+    ];
+
+    public function task()
+    {
+        return $this->belongsTo(ModuleTask::class, 'module_task_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_08_05_000000_create_task_submissions_table.php
+++ b/database/migrations/2025_08_05_000000_create_task_submissions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('task_submissions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('module_task_id')->constrained('module_tasks')->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('file_path')->nullable();
+            $table->text('answer')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('task_submissions');
+    }
+};

--- a/resources/views/front/learning.blade.php
+++ b/resources/views/front/learning.blade.php
@@ -107,11 +107,7 @@
                                         @if(in_array($task->id, $progress->completed_tasks ?? []))
                                             <span class="text-green-600">✔</span>
                                         @else
-                                            <form method="POST" action="{{ route('learning.item.complete', [$course, $task->id]) }}">
-                                                @csrf
-                                                <input type="hidden" name="type" value="task">
-                                                <button type="submit" class="text-xs text-blue-500">Mark as done</button>
-                                            </form>
+                                            <a href="{{ route('task.submit.create', $task) }}" class="text-xs text-blue-500">Submit Task</a>
                                         @endif
                                     </div>
                                 @endforeach

--- a/resources/views/front/task_submissions/create.blade.php
+++ b/resources/views/front/task_submissions/create.blade.php
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="{{asset('css//output.css')}}" rel="stylesheet">
+</head>
+<body class="text-black font-poppins pt-10 pb-[50px]">
+    <div class="max-w-[1200px] mx-auto w-full flex flex-col gap-10">
+        @include('front.partials.nav')
+        <h2 class="font-bold text-2xl">Submit Task</h2>
+        <div class="bg-white p-6 rounded-2xl shadow w-full max-w-lg">
+            <p class="font-semibold mb-4">{{ $task->name }}</p>
+            <p class="mb-4">{{ $task->description }}</p>
+            <form method="POST" action="{{ route('task.submit.store', $task) }}" enctype="multipart/form-data" class="flex flex-col gap-4">
+                @csrf
+                <div>
+                    <label class="block mb-1">File (optional)</label>
+                    <input type="file" name="file">
+                </div>
+                <div>
+                    <label class="block mb-1">Answer (optional)</label>
+                    <textarea name="answer" class="w-full border rounded p-2"></textarea>
+                </div>
+                <button type="submit" class="p-2 bg-blue-600 text-white rounded">Submit</button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\{
     ModuleVideoController,
     ModuleMaterialController,
     ModuleTaskController,
+    TaskSubmissionController,
     SubscribeTransactionController,
     TrainerController,
     FinalQuizController,
@@ -70,6 +71,13 @@ Route::middleware('auth')->group(function () {
 
     Route::post('/learning/{course}/{item}/complete', [FrontController::class, 'markItemComplete'])
         ->name('learning.item.complete')
+        ->middleware('role:trainee');
+
+    Route::get('/task/{task}/submit', [TaskSubmissionController::class, 'create'])
+        ->name('task.submit.create')
+        ->middleware('role:trainee');
+    Route::post('/task/{task}/submit', [TaskSubmissionController::class, 'store'])
+        ->name('task.submit.store')
         ->middleware('role:trainee');
 
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');

--- a/tests/Feature/CurriculumStructureTest.php
+++ b/tests/Feature/CurriculumStructureTest.php
@@ -73,7 +73,7 @@ class CurriculumStructureTest extends TestCase
         $this->assertEquals(66, $progress->progress);
         $this->assertCount(1, $progress->completed_materials);
 
-        $this->post(route('learning.item.complete', [$course->id, $task->id]), ['type' => 'task']);
+        $this->post(route('task.submit.store', $task->id), ['answer' => 'done']);
         $progress->refresh();
         $this->assertEquals(100, $progress->progress);
         $this->assertCount(1, $progress->completed_tasks);


### PR DESCRIPTION
## Summary
- create `TaskSubmission` model and migration
- implement `TaskSubmissionController` for trainees to submit tasks
- add views and routes for submitting module tasks
- link tasks in learning page to submission form
- update curriculum test for new submission flow

## Testing
- `vendor/bin/phpunit --filter CurriculumStructureTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847723df7608321bef2aa181298aff5