### PR TITLE
Add task submission management and improve course pages

### DIFF
--- a/app/Http/Controllers/TaskSubmissionManagementController.php
+++ b/app/Http/Controllers/TaskSubmissionManagementController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\{Course, TaskSubmission};
+use Illuminate\Http\Request;
+
+class TaskSubmissionManagementController extends Controller
+{
+    public function index(Course $course)
+    {
+        $submissions = TaskSubmission::with(['task.module.course', 'user'])
+            ->whereHas('task.module', function ($q) use ($course) {
+                $q->where('course_id', $course->id);
+            })
+            ->get();
+
+        return view('admin.task_submissions.index', compact('course', 'submissions'));
+    }
+
+    public function update(Request $request, TaskSubmission $submission)
+    {
+        $data = $request->validate(['grade' => 'nullable|integer']);
+        $submission->update($data);
+        return back();
+    }
+}

--- a/app/Models/TaskSubmission.php
+++ b/app/Models/TaskSubmission.php
@@ -14,6 +14,11 @@ class TaskSubmission extends Model
         'user_id',
         'file_path',
         'answer',
+        'grade',
+    ];
+
+    protected $casts = [
+        'grade' => 'integer',
     ];
 
     public function task()

--- a/database/migrations/2025_08_05_100000_add_grade_to_task_submissions_table.php
+++ b/database/migrations/2025_08_05_100000_add_grade_to_task_submissions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('task_submissions', function (Blueprint $table) {
+            $table->integer('grade')->nullable()->after('answer');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('task_submissions', function (Blueprint $table) {
+            $table->dropColumn('grade');
+        });
+    }
+};

--- a/resources/views/admin/courses/show.blade.php
+++ b/resources/views/admin/courses/show.blade.php
@@ -87,9 +87,10 @@
                         <h3 class="text-indigo-950 text-xl font-bold">Modules</h3>
                         <p class="text-slate-500 text-sm">{{ $course->modules->count() }}</p>
                     </div>
-                    <a href="{{ route('admin.curriculum.index', $course) }}" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">
-                        Manage Curriculum
-                    </a>
+                    <div class="flex gap-2">
+                        <a href="{{ route('admin.curriculum.index', $course) }}" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">Manage Curriculum</a>
+                        <a href="{{ route('admin.task_submissions.index', $course) }}" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">Task Submissions</a>
+                    </div>
                 </div>
 
                 @foreach($course->modules as $module)

--- a/resources/views/admin/task_submissions/index.blade.php
+++ b/resources/views/admin/task_submissions/index.blade.php
@@ -1,0 +1,49 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Task Submissions for ') }}{{ $course->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead>
+                        <tr>
+                            <th class="px-3 py-2 text-left">Trainee</th>
+                            <th class="px-3 py-2 text-left">Task</th>
+                            <th class="px-3 py-2 text-left">Answer</th>
+                            <th class="px-3 py-2 text-left">File</th>
+                            <th class="px-3 py-2 text-left">Grade</th>
+                            <th class="px-3 py-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200">
+                        @foreach($submissions as $submission)
+                            <tr>
+                                <td class="px-3 py-2">{{ $submission->user->name }}</td>
+                                <td class="px-3 py-2">{{ $submission->task->name }}</td>
+                                <td class="px-3 py-2">{{ $submission->answer }}</td>
+                                <td class="px-3 py-2">
+                                    @if($submission->file_path)
+                                        <a href="{{ Storage::url($submission->file_path) }}" class="text-blue-500" target="_blank">Download</a>
+                                    @endif
+                                </td>
+                                <td class="px-3 py-2">
+                                    <form action="{{ route('admin.task_submissions.update', $submission) }}" method="POST" class="flex items-center gap-2">
+                                        @csrf
+                                        @method('PATCH')
+                                        <input type="number" name="grade" value="{{ $submission->grade }}" class="border rounded p-1 w-20">
+                                        <button type="submit" class="px-2 py-1 bg-indigo-600 text-white rounded">Save</button>
+                                    </form>
+                                </td>
+                                <td class="px-3 py-2"></td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/front/explore.blade.php
+++ b/resources/views/front/explore.blade.php
@@ -79,29 +79,18 @@
 
             <!-- Course List -->
             <div class="flex-1">
-                <div id="courseContent" class="flex flex-col gap-6">
+                <div id="courseContent" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                     @foreach($courses as $course)
-                    <div class="bg-white rounded-xl shadow-md overflow-hidden flex flex-col md:flex-row transition hover:shadow-lg hover:scale-[1.01]">
-                        <div class="w-full md:w-1/3 h-48 md:h-auto overflow-hidden">
-                            <img src="{{ $course->thumbnail ? Storage::url($course->thumbnail) : asset('assets/default-course.jpg') }}"
-                                alt="{{ $course->name }}" class="w-full h-full object-cover">
-                        </div>
-                        <div class="p-4 flex flex-col justify-between md:w-2/3">
-                            <div>
-                                <h2 class="text-xl font-semibold line-clamp-2">{{ $course->name }}</h2>
-                                <p class="text-sm text-gray-600">Trainer: {{ $course->trainer?->user?->name ?? 'Unknown' }}</p>
-                                <p class="text-sm font-semibold">{{ $course->price > 0 ? 'Rp ' . number_format($course->price, 0, ',', '.') : 'FREE' }}</p>
-                                <div class="flex flex-wrap items-center text-xs text-gray-600 gap-2 my-2">
-                                    <span class="bg-gray-100 px-2 py-1 rounded-full">Level: {{ $course->level->name ?? '-' }}</span>
-                                    <span class="bg-gray-100 px-2 py-1 rounded-full">Mode: {{ $course->mode->name ?? '-' }}</span>
-                                </div>
-                            </div>
-                            <div class="mt-3">
-                                <a href="{{ route('front.details', $course->slug) }}"
-                                    class="inline-block bg-[#FF6129] text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-[#e85520] transition-all">
-                                    Lihat Detail
-                                </a>
-                            </div>
+                    <div class="flex flex-col rounded-xl bg-white overflow-hidden transition-all hover:ring-2 hover:ring-[#FF6129]">
+                        <a href="{{ route('front.details', $course->slug) }}" class="w-full h-48 overflow-hidden">
+                            <img src="{{ $course->thumbnail ? Storage::url($course->thumbnail) : asset('assets/default-course.jpg') }}" class="w-full h-full object-cover" alt="thumbnail">
+                        </a>
+                        <div class="p-4 flex flex-col gap-2">
+                            <a href="{{ route('front.details', $course->slug) }}" class="font-semibold text-lg line-clamp-2 hover:underline">{{ $course->name }}</a>
+                            <p class="text-sm text-gray-600">Trainer: {{ $course->trainer?->user?->name ?? 'Unknown' }}</p>
+                            <p class="text-sm text-gray-600">{{ $course->mode->name ?? '' }} - {{ $course->level->name ?? '' }}</p>
+                            <p class="font-semibold">{{ $course->price > 0 ? 'Rp ' . number_format($course->price, 0, ',', '.') : 'FREE' }}</p>
+                            <a href="{{ route('front.details', $course->slug) }}" class="mt-2 inline-block bg-[#FF6129] text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-[#e85520] transition-all">Lihat Detail</a>
                         </div>
                     </div>
                     @endforeach

--- a/resources/views/front/my_courses.blade.php
+++ b/resources/views/front/my_courses.blade.php
@@ -55,31 +55,35 @@
 
         <!-- Konten -->
         <div class="px-[50px]" id="courseContent">
-            <div class="grid grid-cols-1 gap-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 @foreach($courses as $course)
-                <div class="bg-white rounded-xl shadow-md overflow-hidden flex flex-col md:flex-row transition hover:shadow-lg hover:scale-[1.01]">
-                    <div class="w-full md:w-1/3 h-48 md:h-auto overflow-hidden">
-                        <img src="{{ $course->thumbnail ? Storage::url($course->thumbnail) : asset('assets/default-course.jpg') }}" 
-                            alt="{{ $course->name }}" class="w-full h-full object-cover">
-                    </div>
-                    <div class="p-4 flex flex-col justify-between md:w-2/3">
-                        <div>
-                            <h2 class="text-xl font-semibold line-clamp-2">{{ $course->name }}</h2>
-                            <p class="text-sm text-gray-600">Trainer: {{ $course->trainer?->user?->name ?? 'Unknown' }}</p>
-                            <div class="flex flex-wrap items-center text-xs text-gray-600 gap-2 my-2">
-                                <span class="bg-gray-100 px-2 py-1 rounded-full">Level: {{ $course->level->name ?? '-' }}</span>
-                                <span class="bg-gray-100 px-2 py-1 rounded-full">Mode: {{ $course->mode->name ?? '-' }}</span>
-                            </div>
-                        </div>
-                        <div class="mt-3">
-                            <a href="{{ route('front.details', $course->slug) }}" class="inline-block bg-[#FF6129] text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-[#e85520] transition-all">
-                                Mulai Belajar
-                            </a>
-                        </div>
+                <div class="flex flex-col rounded-xl bg-white overflow-hidden transition-all hover:ring-2 hover:ring-[#FF6129]">
+                    <a href="{{ route('front.details', $course->slug) }}" class="w-full h-48 overflow-hidden">
+                        <img src="{{ $course->thumbnail ? Storage::url($course->thumbnail) : asset('assets/default-course.jpg') }}" class="w-full h-full object-cover" alt="thumbnail">
+                    </a>
+                    <div class="p-4 flex flex-col gap-2">
+                        <a href="{{ route('front.details', $course->slug) }}" class="font-semibold text-lg line-clamp-2 hover:underline">{{ $course->name }}</a>
+                        <p class="text-sm text-gray-600">Trainer: {{ $course->trainer?->user?->name ?? 'Unknown' }}</p>
+                        <p class="text-sm text-gray-600">{{ $course->mode->name ?? '' }} - {{ $course->level->name ?? '' }}</p>
+                        <a href="{{ route('front.details', $course->slug) }}" class="mt-2 inline-block bg-[#FF6129] text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-[#e85520] transition-all">Mulai Belajar</a>
                     </div>
                 </div>
                 @endforeach
             </div>
+
+            @if(count($tasksToDo))
+            <div class="mt-10">
+                <h2 class="text-xl font-semibold mb-4">Pending Tasks</h2>
+                <ul class="space-y-2">
+                    @foreach($tasksToDo as $task)
+                        <li class="bg-white p-4 rounded shadow flex justify-between items-center">
+                            <span>{{ $task->module->course->name }} → {{ $task->name }}</span>
+                            <a href="{{ route('task.submit.create', $task) }}" class="text-blue-600">Submit</a>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+            @endif
         </div>
     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -128,6 +128,8 @@ Route::middleware('auth')->group(function () {
           Route::get('courses/{course}/quiz/edit', [FinalQuizController::class, 'edit'])->name('course_quiz.edit');
           Route::put('courses/{course}/quiz', [FinalQuizController::class, 'update'])->name('course_quiz.update');
 
+          Route::get('courses/{course}/task-submissions', [TaskSubmissionManagementController::class, 'index'])->name('task_submissions.index');
+          Route::patch('task-submissions/{submission}', [TaskSubmissionManagementController::class, 'update'])->name('task_submissions.update');
 
         });
     });


### PR DESCRIPTION
## Summary
- allow grading of task submissions by adding a grade column and management controller
- show a link in course admin page to manage submissions
- display submissions table for trainers
- list pending tasks on My Courses page
- improve Explore and My Courses layouts with card-style grid

## Testing
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475065e5088321860e1eb67744a24f