### PR TITLE
Implement secure material and submission downloads

### DIFF
--- a/app/Http/Controllers/TaskSubmissionManagementController.php
+++ b/app/Http/Controllers/TaskSubmissionManagementController.php
@@ -2,8 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\{Course, TaskSubmission};
+use App\Models\{Course, TaskSubmission, Trainer};
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\{Auth, Storage};
 
 class TaskSubmissionManagementController extends Controller
 {
@@ -23,5 +24,28 @@ class TaskSubmissionManagementController extends Controller
         $data = $request->validate(['grade' => 'nullable|integer']);
         $submission->update($data);
         return back();
+    }
+
+    public function download(TaskSubmission $submission)
+    {
+        $user = Auth::user();
+        $course = $submission->task->module->course;
+
+        $allowed = false;
+
+        if ($user->hasRole('admin')) {
+            $allowed = true;
+        } elseif ($user->hasRole('trainer')) {
+            $trainer = Trainer::where('user_id', $user->id)->first();
+            if ($trainer && $course->trainer_id === $trainer->id) {
+                $allowed = true;
+            }
+        }
+
+        abort_unless($allowed, 403);
+
+        abort_if(!$submission->file_path, 404);
+
+        return Storage::disk('public')->download($submission->file_path, basename($submission->file_path));
     }
 }

--- a/resources/views/admin/task_submissions/index.blade.php
+++ b/resources/views/admin/task_submissions/index.blade.php
@@ -27,7 +27,7 @@
                                 <td class="px-3 py-2">{{ $submission->answer }}</td>
                                 <td class="px-3 py-2">
                                     @if($submission->file_path)
-                                        <a href="{{ Storage::url($submission->file_path) }}" class="text-blue-500" target="_blank">Download</a>
+                                        <a href="{{ route('admin.task_submissions.download', $submission) }}" class="text-blue-500">Download</a>
                                     @endif
                                 </td>
                                 <td class="px-3 py-2">

--- a/resources/views/front/learning.blade.php
+++ b/resources/views/front/learning.blade.php
@@ -77,7 +77,7 @@
 
                                 @foreach($module->materials as $material)
                                     <div class="flex items-center gap-2">
-                                        <a href="{{ Storage::url($material->file_path) }}" class="flex-1 group p-[12px_16px] flex items-center gap-[10px] bg-[#E9EFF3] rounded-full hover:bg-[#3525B3] transition-all">
+                                        <a href="{{ route('materials.download', $material) }}" class="flex-1 group p-[12px_16px] flex items-center gap-[10px] bg-[#E9EFF3] rounded-full hover:bg-[#3525B3] transition-all">
                                             <div class="text-black group-hover:text-white">📄</div>
                                             <p class="font-semibold group-hover:text-white">{{ $material->name }}</p>
                                         </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,9 @@ Route::middleware('auth')->group(function () {
         ->name('task.submit.store')
         ->middleware('role:trainee');
 
+    Route::get('/materials/{material}/download', [CourseMaterialController::class, 'download'])
+        ->name('materials.download');
+
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
     // ====================
@@ -130,6 +133,7 @@ Route::middleware('auth')->group(function () {
 
           Route::get('courses/{course}/task-submissions', [TaskSubmissionManagementController::class, 'index'])->name('task_submissions.index');
           Route::patch('task-submissions/{submission}', [TaskSubmissionManagementController::class, 'update'])->name('task_submissions.update');
+          Route::get('task-submissions/{submission}/download', [TaskSubmissionManagementController::class, 'download'])->name('task_submissions.download');
 
         });
     });


### PR DESCRIPTION
## Summary
- add download permission check for course materials
- provide trainer/admin download of task submissions
- create routes for downloading materials and submissions
- update frontend and admin links to use new download endpoints

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477fcfbadc8321bddd540fbda5fe44