### PR TITLE
Update README with storage link step

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ cd WebPelatihan
 composer install
 npm install
 
+# Link storage for uploaded files (course materials, task submissions, etc.)
+php artisan storage:link
+
 # Environment setup
 cp .env.example .env
 php artisan key:generate
@@ -78,6 +81,9 @@ npm run build
 # Start development server
 php artisan serve
 ```
+
+Running `php artisan storage:link` ensures that uploaded files such as course
+materials and task submissions can be served properly.
 
 ## 👤 **Default Test Accounts**
 


### PR DESCRIPTION
## Summary
- document the need to link storage during installation
- clarify that `php artisan storage:link` is required for serving uploaded files

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68477f28cfc08321b268be8fcca0cbec