### PR TITLE
Fix download file name for course materials

### DIFF
--- a/app/Http/Controllers/CourseMaterialController.php
+++ b/app/Http/Controllers/CourseMaterialController.php
@@ -46,6 +46,15 @@ class CourseMaterialController extends Controller
 
         abort_unless($allowed, 403);
 
-        return Storage::disk('public')->download($material->file_path, $material->name);
+        $downloadName = $material->name;
+        // Ensure the downloaded file includes the correct extension
+        if ($material->file_type) {
+            $extension = '.' . ltrim($material->file_type, '.');
+            if (!str_ends_with(strtolower($downloadName), strtolower($extension))) {
+                $downloadName .= $extension;
+            }
+        }
+
+        return Storage::disk('public')->download($material->file_path, $downloadName);
     }
 }


### PR DESCRIPTION
## Summary
- ensure course material downloads use the correct filename and extension

## Testing
- `phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847835852748321961de79fca80c8ed