### PR TITLE
Change active video link color

### DIFF
--- a/resources/views/front/details.blade.php
+++ b/resources/views/front/details.blade.php
@@ -54,12 +54,12 @@
                 class="group p-[12px_16px] flex items-center gap-[10px] rounded-full transition-all duration-300
                     {{ $isActive ? 'bg-[#3525B3]' : 'bg-[#E9EFF3] hover:bg-[#3525B3]' }}"
             >
-                <div class="text-black group-hover:text-white {{ $isActive ? 'text-white' : '' }} transition-all duration-300">
+                <div class="text-black group-hover:text-white {{ $isActive ? 'text-[#3525B3]' : '' }} transition-all duration-300">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
                         <path d="M11.97 2C6.45 2 1.97 6.48 1.97 12s4.48 10 10 10 10-4.48 10-10S17.5 2 11.97 2Zm3 12.23-2.9 1.67c-.36.21-.76.31-1.15.31s-.79-.1-1.15-.31c-.72-.42-1.15-1.16-1.15-2V10.55c0-.83.43-1.57 1.15-1.99.72-.42 1.6-.42 2.32 0l2.9 1.67c.72.42 1.15 1.16 1.15 1.99s-.43 1.57-1.15 1.99Z" fill="currentColor"/>
                     </svg>
                 </div>
-                <p class="font-semibold transition-all duration-300 {{ $isActive ? 'text-white' : 'group-hover:text-white text-black' }}">
+                <p class="font-semibold transition-all duration-300 {{ $isActive ? 'text-[#3525B3]' : 'group-hover:text-white text-black' }}">
                     {{ $video->name }}
                 </p>
             </a>

--- a/resources/views/front/learning.blade.php
+++ b/resources/views/front/learning.blade.php
@@ -54,8 +54,8 @@
                                     @if($hasAccess || $course->price == 0)
                                         <div class="flex items-center gap-2">
                                             <a href="{{ route('front.learning', [$course, 'courseVideoId' => $video->id]) }}" class="flex-1 group p-[12px_16px] flex items-center gap-[10px] rounded-full transition-all duration-300 {{ $isActive ? 'bg-[#3525B3] active-video' : 'bg-[#E9EFF3] hover:bg-[#3525B3]' }}">
-                                                <div class="text-black group-hover:text-white {{ $isActive ? 'text-white' : '' }}">▶️</div>
-                                                <p class="font-semibold {{ $isActive ? 'text-white' : 'group-hover:text-white text-black' }}">{{ $video->name }}</p>
+                                                <div class="text-black group-hover:text-white {{ $isActive ? 'text-[#3525B3]' : '' }}">▶️</div>
+                                                <p class="font-semibold {{ $isActive ? 'text-[#3525B3]' : 'group-hover:text-white text-black' }}">{{ $video->name }}</p>
                                             </a>
                                             @if(in_array($video->id, $progress->completed_videos ?? []))
                                                 <span class="text-green-600">✔</span>


### PR DESCRIPTION
## Summary
- swap active video text color to blue in learning page
- use same active color in course details list

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68478b54519c83219f8cfd0ba08adc3e