### PR TITLE
Improve cart UI and actions

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,9 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Auth;
+use App\Models\CartItem;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -32,5 +35,13 @@ class AppServiceProvider extends ServiceProvider
         // Set Carbon timezone and locale
         Carbon::setLocale('id'); // Indonesian locale
         // Carbon will use the application timezone set by date_default_timezone_set() above
+
+        View::composer('*', function ($view) {
+            $count = 0;
+            if (Auth::check()) {
+                $count = CartItem::where('user_id', Auth::id())->count();
+            }
+            $view->with('cartCount', $count);
+        });
     }
 }

--- a/resources/views/front/cart.blade.php
+++ b/resources/views/front/cart.blade.php
@@ -14,11 +14,17 @@
         @forelse($items as $item)
             <li class="flex justify-between items-center border-b pb-2">
                 <span>{{ $item->course->name }}</span>
-                <form action="{{ route('cart.destroy', $item) }}" method="POST">
-                    @csrf
-                    @method('DELETE')
-                    <button class="text-red-600">Remove</button>
-                </form>
+                <div class="flex gap-2 items-center">
+                    <form action="{{ route('courses.join', $item->course->slug) }}" method="POST">
+                        @csrf
+                        <button class="px-2 py-1 rounded bg-blue-600 text-white text-sm">Join Now</button>
+                    </form>
+                    <form action="{{ route('cart.destroy', $item) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button class="text-red-600 text-sm">Remove</button>
+                    </form>
+                </div>
             </li>
         @empty
             <li>No items in cart.</li>

--- a/resources/views/front/explore.blade.php
+++ b/resources/views/front/explore.blade.php
@@ -8,7 +8,7 @@
     <!-- CSS -->
     <link rel="stylesheet" href="https://unpkg.com/flickity@2/dist/flickity.min.css">
 </head>
-<body class="text-black font-poppins pt-10 pb-10 bg-gray-50">
+<body class="text-black font-poppins pt-10 pb-10 bg-gray-100">
     <div class="max-w-[1200px] mx-auto">
         <nav class="flex justify-between items-center py-6 px-[50px]">
             <div class="flex items-center gap-3">
@@ -23,8 +23,11 @@
                 <li><a href="#" class="font-semibold">My Certificate</a></li>
                 <li><a href="{{ route('courses.my') }}" class="font-semibold">My Course</a></li>
                 <li>
-                    <a href="{{ route('cart.index') }}" class="flex items-center">
+                    <a href="{{ route('cart.index') }}" class="relative flex items-center">
                         <img src="{{ asset('asset/vendor/fontawesome-free/svgs/solid/shopping-cart.svg') }}" class="w-5 h-5" alt="cart">
+                        @if($cartCount > 0)
+                        <span class="absolute -top-2 -right-2 w-4 h-4 text-xs text-white bg-red-500 rounded-full flex items-center justify-center">{{ $cartCount }}</span>
+                        @endif
                     </a>
                 </li>
             </ul>
@@ -36,7 +39,6 @@
                 <div class="absolute right-0 mt-2 bg-white border rounded shadow hidden" id="dropdownMenu">
                     <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Profile Settings</a>
                     <a href="{{ route('courses.my') }}" class="block px-4 py-2 hover:bg-gray-100">My Course</a>
-                    <a href="{{ route('cart.index') }}" class="block px-4 py-2 hover:bg-gray-100">My Cart</a>
                     <a href="{{ route('dashboard') }}" class="block px-4 py-2 hover:bg-gray-100">Dashboard</a>
                 </div>
             </div>

--- a/resources/views/front/index.blade.php
+++ b/resources/views/front/index.blade.php
@@ -29,8 +29,11 @@
             <a href="{{ route('courses.my') }}" class="font-semibold">My Course</a>
         </li>
         <li>
-            <a href="{{ route('cart.index') }}" class="flex items-center">
+            <a href="{{ route('cart.index') }}" class="relative flex items-center">
                 <img src="{{ asset('asset/vendor/fontawesome-free/svgs/solid/shopping-cart.svg') }}" class="w-5 h-5" alt="cart">
+                @if($cartCount > 0)
+                <span class="absolute -top-2 -right-2 w-4 h-4 text-xs text-white bg-red-500 rounded-full flex items-center justify-center">{{ $cartCount }}</span>
+                @endif
             </a>
         </li>
     </ul>
@@ -48,7 +51,6 @@
                 <div class="absolute right-0 mt-2 bg-white border rounded shadow hidden" id="dropdownMenu">
                     <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Profile Settings</a>
                     <a href="{{ route('courses.my') }}" class="block px-4 py-2 hover:bg-gray-100">My Course</a>
-                    <a href="{{ route('cart.index') }}" class="block px-4 py-2 hover:bg-gray-100">My Cart</a>
                     <a href="{{ route('dashboard') }}" class="block px-4 py-2 hover:bg-gray-100">Dashboard</a>
                     <form method="POST" action="{{ route('logout') }}" class="inline">
                         @csrf

--- a/resources/views/front/my_courses.blade.php
+++ b/resources/views/front/my_courses.blade.php
@@ -8,7 +8,7 @@
     <!-- CSS -->
     <link rel="stylesheet" href="https://unpkg.com/flickity@2/dist/flickity.min.css">
 </head>
-<body class="text-black font-poppins pt-10 pb-10 bg-gray-50">
+<body class="text-black font-poppins pt-10 pb-10 bg-gray-100">
     <div class="max-w-[1200px] mx-auto">
         <!-- Navbar -->
         <nav class="flex justify-between items-center py-6 px-[50px] bg-white shadow rounded-xl mb-6">
@@ -24,8 +24,11 @@
                 <li><a href="#" class="font-semibold">My Certificate</a></li>
                 <li><a href="{{ route('courses.my') }}" class="font-semibold">My Course</a></li>
                 <li>
-                    <a href="{{ route('cart.index') }}" class="flex items-center">
+                    <a href="{{ route('cart.index') }}" class="relative flex items-center">
                         <img src="{{ asset('asset/vendor/fontawesome-free/svgs/solid/shopping-cart.svg') }}" class="w-5 h-5" alt="cart">
+                        @if($cartCount > 0)
+                        <span class="absolute -top-2 -right-2 w-4 h-4 text-xs text-white bg-red-500 rounded-full flex items-center justify-center">{{ $cartCount }}</span>
+                        @endif
                     </a>
                 </li>
             </ul>
@@ -37,7 +40,6 @@
                 <div class="absolute right-0 mt-2 bg-white border rounded shadow hidden z-10" id="dropdownMenu">
                     <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Profile Settings</a>
                     <a href="{{ route('courses.my') }}" class="block px-4 py-2 hover:bg-gray-100">My Course</a>
-                    <a href="{{ route('cart.index') }}" class="block px-4 py-2 hover:bg-gray-100">My Cart</a>
                     <a href="{{ route('dashboard') }}" class="block px-4 py-2 hover:bg-gray-100">Dashboard</a>
                 </div>
             </div>

--- a/resources/views/front/partials/nav.blade.php
+++ b/resources/views/front/partials/nav.blade.php
@@ -11,8 +11,11 @@
         <li><a href="" class="font-semibold">My Certificate</a></li>
         <li><a href="{{ route('courses.my') }}" class="font-semibold">My Course</a></li>
         <li>
-            <a href="{{ route('cart.index') }}" class="flex items-center">
+            <a href="{{ route('cart.index') }}" class="relative flex items-center">
                 <img src="{{ asset('asset/vendor/fontawesome-free/svgs/solid/shopping-cart.svg') }}" class="w-5 h-5" alt="cart">
+                @if($cartCount > 0)
+                <span class="absolute -top-2 -right-2 w-4 h-4 text-xs text-white bg-red-500 rounded-full flex items-center justify-center">{{ $cartCount }}</span>
+                @endif
             </a>
         </li>
     </ul>
@@ -30,7 +33,6 @@
         <div class="absolute right-0 mt-2 bg-white border rounded shadow hidden" id="dropdownMenu">
             <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Profile Settings</a>
             <a href="{{ route('courses.my') }}" class="block px-4 py-2 hover:bg-gray-100">My Course</a>
-            <a href="{{ route('cart.index') }}" class="block px-4 py-2 hover:bg-gray-100">My Cart</a>
             <a href="{{ route('dashboard') }}" class="block px-4 py-2 hover:bg-gray-100">Dashboard</a>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add view composer for cartCount
- style explore and my course pages with gray background
- display cart item count badge in navbars
- remove My Cart from profile dropdown
- allow joining course directly from cart

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492a9a28b08321ac8d05b6af0fed3f