### PR TITLE
Improve asset URLs for avatars and thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ npm install
 
 # Link storage for uploaded files (course materials, task submissions, etc.)
 php artisan storage:link
+# This command exposes user avatars and course thumbnails stored on the
+# public disk so they can be served by the web server
 
 # Environment setup
 cp .env.example .env

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\Certificate;
 use App\Models\CourseModule;
+use Illuminate\Support\Facades\Storage;
 
 class Course extends Model
 {
@@ -54,6 +55,18 @@ class Course extends Model
     public function modules()
     {
         return $this->hasMany(CourseModule::class)->orderBy('order');
+    }
+
+    /**
+     * Get the thumbnail URL with fallback to default
+     */
+    public function getThumbnailUrlAttribute(): string
+    {
+        if ($this->thumbnail && Storage::disk('public')->exists($this->thumbnail)) {
+            return Storage::url($this->thumbnail);
+        }
+
+        return asset('assets/default-course.jpg');
     }
 
     // App\Models\Course.php

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
@@ -73,8 +74,8 @@ class User extends Authenticatable
      */
     public function getAvatarUrlAttribute(): string
     {
-        if ($this->avatar && file_exists(public_path($this->avatar))) {
-            return asset($this->avatar);
+        if ($this->avatar && \Illuminate\Support\Facades\Storage::disk('public')->exists($this->avatar)) {
+            return \Illuminate\Support\Facades\Storage::url($this->avatar);
         }
 
         // Fallback to default avatar

--- a/resources/views/front/details.blade.php
+++ b/resources/views/front/details.blade.php
@@ -174,7 +174,7 @@
                     <div class="flex items-center gap-2">
                         <div class="w-8 h-8 rounded-full overflow-hidden">
                             <img
-                                src="{{ $trainerUser->avatar ? Storage::url($trainerUser->avatar) : asset('images/default-avatar.png') }}"
+                                src="{{ $trainerUser->avatar_url ?? asset('images/default-avatar.png') }}"
                                 class="w-full h-full object-cover"
                                 alt="avatar">
                         </div>

--- a/resources/views/front/explore.blade.php
+++ b/resources/views/front/explore.blade.php
@@ -34,7 +34,7 @@
             @auth
             <div class="relative" id="dropdownWrapper">
                 <div class="w-[56px] h-[56px] overflow-hidden rounded-full cursor-pointer" id="dropdownAvatar">
-                    <img src="{{ Storage::url(Auth::user()->avatar) }}" class="w-full h-full object-cover" alt="photo">
+                    <img src="{{ Auth::user()->avatar_url }}" class="w-full h-full object-cover" alt="photo">
                 </div>
                 <div class="absolute right-0 mt-2 bg-white border rounded shadow hidden" id="dropdownMenu">
                     <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Profile Settings</a>
@@ -85,7 +85,7 @@
                     @foreach($courses as $course)
                     <div class="flex flex-col rounded-xl bg-white overflow-hidden transition-all hover:ring-2 hover:ring-[#FF6129]">
                         <a href="{{ route('front.details', $course->slug) }}" class="w-full h-48 overflow-hidden">
-                            <img src="{{ $course->thumbnail ? Storage::url($course->thumbnail) : asset('assets/default-course.jpg') }}" class="w-full h-full object-cover" alt="thumbnail">
+                            <img src="{{ $course->thumbnail_url }}" class="w-full h-full object-cover" alt="thumbnail">
                         </a>
                         <div class="p-4 flex flex-col gap-2">
                             <a href="{{ route('front.details', $course->slug) }}" class="font-semibold text-lg line-clamp-2 hover:underline">{{ $course->name }}</a>

--- a/resources/views/front/index.blade.php
+++ b/resources/views/front/index.blade.php
@@ -46,7 +46,7 @@
                     @endif
                 </div>
                 <div class="w-[56px] h-[56px] overflow-hidden rounded-full flex shrink-0 cursor-pointer" id="dropdownAvatar">
-                    <img src="{{Storage::url(Auth::user()->avatar)}}" class="w-full h-full object-cover" alt="photo">
+                    <img src="{{ Auth::user()->avatar_url }}" class="w-full h-full object-cover" alt="photo">
                 </div>
                 <div class="absolute right-0 mt-2 bg-white border rounded shadow hidden" id="dropdownMenu">
                     <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Profile Settings</a>
@@ -133,7 +133,7 @@
                     <div class="course-card px-3 pb-[70px] mt-[2px]">
                         <div class="flex flex-col rounded-t-[12px] rounded-b-[24px] gap-[32px] bg-white w-full pb-[10px] overflow-hidden transition-all duration-300 hover:ring-2 hover:ring-[#FF6129]">
                             <a href="{{ route('front.details', $course->slug) }}" class="thumbnail w-full h-[200px] shrink-0 rounded-[10px] overflow-hidden">
-                                <img src="{{ Storage::url($course->thumbnail) }}" class="w-full h-full object-cover" alt="thumbnail">
+                                <img src="{{ $course->thumbnail_url }}" class="w-full h-full object-cover" alt="thumbnail">
                             </a>
                             <div class="flex flex-col px-4 gap-[10px]">
                                 <a href="{{ route('front.details', $course->slug) }}" class="font-semibold text-lg line-clamp-2 hover:line-clamp-none min-h-[56px]">{{ $course->name }}</a>
@@ -163,7 +163,7 @@
                                 <div class="flex items-center gap-2">
                                     <div class="w-8 h-8 flex shrink-0 rounded-full overflow-hidden">
                                         <img
-                                            src="{{ $trainerUser->avatar ? Storage::url($trainerUser->avatar) : asset('images/default-avatar.png') }}"
+                                            src="{{ $trainerUser->avatar_url ?? asset('images/default-avatar.png') }}"
                                             class="w-full h-full object-cover"
                                             alt="avatar">
                                     </div>

--- a/resources/views/front/my_courses.blade.php
+++ b/resources/views/front/my_courses.blade.php
@@ -35,7 +35,7 @@
             @auth
             <div class="relative" id="dropdownWrapper">
                 <div class="w-[56px] h-[56px] overflow-hidden rounded-full cursor-pointer" id="dropdownAvatar">
-                    <img src="{{ Storage::url(Auth::user()->avatar) }}" class="w-full h-full object-cover" alt="photo">
+                    <img src="{{ Auth::user()->avatar_url }}" class="w-full h-full object-cover" alt="photo">
                 </div>
                 <div class="absolute right-0 mt-2 bg-white border rounded shadow hidden z-10" id="dropdownMenu">
                     <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Profile Settings</a>
@@ -61,7 +61,7 @@
                 @foreach($courses as $course)
                 <div class="flex flex-col rounded-xl bg-white overflow-hidden transition-all hover:ring-2 hover:ring-[#FF6129]">
                     <a href="{{ route('front.details', $course->slug) }}" class="w-full h-48 overflow-hidden">
-                        <img src="{{ $course->thumbnail ? Storage::url($course->thumbnail) : asset('assets/default-course.jpg') }}" class="w-full h-full object-cover" alt="thumbnail">
+                        <img src="{{ $course->thumbnail_url }}" class="w-full h-full object-cover" alt="thumbnail">
                     </a>
                     <div class="p-4 flex flex-col gap-2">
                         <a href="{{ route('front.details', $course->slug) }}" class="font-semibold text-lg line-clamp-2 hover:underline">{{ $course->name }}</a>

--- a/resources/views/front/partials/nav.blade.php
+++ b/resources/views/front/partials/nav.blade.php
@@ -28,7 +28,7 @@
             @endif
         </div>
         <div class="w-[56px] h-[56px] overflow-hidden rounded-full flex shrink-0 cursor-pointer" id="dropdownAvatar">
-            <img src="{{ Storage::url(Auth::user()->avatar) }}" class="w-full h-full object-cover" alt="photo">
+            <img src="{{ Auth::user()->avatar_url }}" class="w-full h-full object-cover" alt="photo">
         </div>
         <div class="absolute right-0 mt-2 bg-white border rounded shadow hidden" id="dropdownMenu">
             <a href="{{ route('profile.edit') }}" class="block px-4 py-2 hover:bg-gray-100">Profile Settings</a>

--- a/resources/views/partials/course-list.blade.php
+++ b/resources/views/partials/course-list.blade.php
@@ -3,7 +3,7 @@
     <div class="course-card w-1/3 px-3 pb-[70px] mt-[2px]">
         <div class="flex flex-col rounded-t-[12px] rounded-b-[24px] gap-[32px] bg-white w-full pb-[10px] overflow-hidden transition-all duration-300 hover:ring-2 hover:ring-[#FF6129]">
             <a href="{{ route('front.details', $course->slug) }}" class="thumbnail w-full h-[200px] shrink-0 rounded-[10px] overflow-hidden">
-                <img src="{{ Storage::url($course->thumbnail) }}" class="w-full h-full object-cover" alt="thumbnail">
+                <img src="{{ $course->thumbnail_url }}" class="w-full h-full object-cover" alt="thumbnail">
             </a>
             <div class="flex flex-col px-4 gap-[10px]">
                 <a href="{{ route('front.details', $course->slug) }}" class="font-semibold text-lg line-clamp-2 hover:line-clamp-none min-h-[56px]">{{ $course->name }}</a>
@@ -32,7 +32,7 @@
 
                 <div class="flex items-center gap-2">
                     <div class="w-8 h-8 flex shrink-0 rounded-full overflow-hidden">
-                        <img src="{{ $trainerUser->avatar ? Storage::url($trainerUser->avatar) : asset('images/default-avatar.png') }}" class="w-full h-full object-cover" alt="avatar">
+                        <img src="{{ $trainerUser->avatar_url ?? asset('images/default-avatar.png') }}" class="w-full h-full object-cover" alt="avatar">
                     </div>
                     <div class="flex flex-col">
                         <p class="font-semibold">{{ $trainerUser->name ?? 'Unknown Trainer' }}</p>


### PR DESCRIPTION
## Summary
- use the public disk to get avatar URLs
- add Course::thumbnail_url accessor
- reference the new accessors in front-end views
- document `php artisan storage:link` requirement

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fcc0152083219e6f3479cb5a585b