### PR TITLE
Display quiz attempt info in learning page

### DIFF
--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -84,6 +84,7 @@ class FrontController extends Controller
             "category", "trainer.user", "trainees",
             "course_videos", "course_keypoints",
             "modules.videos", "modules.materials", "modules.tasks",
+            "finalQuiz",
         ]);
 
         $user = Auth::user();
@@ -134,7 +135,15 @@ class FrontController extends Controller
             ->where('course_id', $course->id)
             ->first();
 
-        return view('front.learning', compact('course', 'video', 'certificate', 'progress'));
+        $quizAttempt = null;
+        if ($course->finalQuiz) {
+            $quizAttempt = $course->finalQuiz->attempts()
+                ->where('user_id', $user->id)
+                ->latest()
+                ->first();
+        }
+
+        return view('front.learning', compact('course', 'video', 'certificate', 'progress', 'quizAttempt'));
     }
 
     /**

--- a/resources/views/front/learning.blade.php
+++ b/resources/views/front/learning.blade.php
@@ -184,11 +184,17 @@
                         <div id="Quiz" class="tabcontent hidden">
                             <div class="flex flex-col gap-5">
                                 <h3 class="font-bold text-2xl">Test Your Knowledge</h3>
-                                <p class="font-medium leading-[30px]">
-                                    Quiz content will be displayed here. This section will contain questions related to the current lesson or course.
-                                </p>
-                                <!-- Placeholder for quiz elements -->
-                                <a href="{{ route('front.quiz', $course) }}" class="text-white font-semibold rounded-[30px] p-[16px_32px] bg-[#FF6129] transition-all duration-300 hover:shadow-[0_10px_20px_0_#FF612980] w-fit">Start Quiz</a>
+                                @if(isset($quizAttempt))
+                                    <p class="font-medium leading-[30px]">
+                                        Score: {{ $quizAttempt->score }}% – {{ $quizAttempt->is_passed ? 'Passed' : 'Failed' }}
+                                    </p>
+                                    @unless($quizAttempt->is_passed)
+                                        <a href="{{ route('front.quiz', $course) }}" class="text-white font-semibold rounded-[30px] p-[16px_32px] bg-[#FF6129] transition-all duration-300 hover:shadow-[0_10px_20px_0_#FF612980] w-fit">Retake Quiz</a>
+                                    @endunless
+                                @else
+                                    <p class="font-medium leading-[30px]">Quiz content will be displayed here. This section will contain questions related to the current lesson or course.</p>
+                                    <a href="{{ route('front.quiz', $course) }}" class="text-white font-semibold rounded-[30px] p-[16px_32px] bg-[#FF6129] transition-all duration-300 hover:shadow-[0_10px_20px_0_#FF612980] w-fit">Start Quiz</a>
+                                @endif
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- load latest quiz attempt in `FrontController@learning`
- show score and pass/fail status or retake button in `learning.blade`

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ff429b38832182d144ccab526900