### PR TITLE
Improve quiz navigation and timer

### DIFF
--- a/app/Http/Controllers/QuizAttemptController.php
+++ b/app/Http/Controllers/QuizAttemptController.php
@@ -16,8 +16,10 @@ class QuizAttemptController extends Controller
     public function show(Course $course) // Laravel akan otomatis mengambil objek Course berdasarkan ID dari URL
     {
         $quiz = FinalQuiz::where('course_id', $course->id)
-                         ->with('questions.options') // Pastikan relasi 'options' ada di model QuizQuestion
-                         ->firstOrFail(); // Ambil kuis pertama yang terkait dengan kursus ini
+            ->with(['questions' => function ($query) {
+                $query->orderBy('id')->with('options');
+            }]) // Pastikan pertanyaan terurut dan memuat opsi
+            ->firstOrFail(); // Ambil kuis pertama yang terkait dengan kursus ini
 
         // Mengirim data ke view 'front.quiz.blade.php'
         return view('front.quiz', compact('quiz', 'course'));


### PR DESCRIPTION
## Summary
- order quiz questions in controller
- display only one question at a time with sidebar navigation
- add countdown timer and autosubmit when time runs out

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a020e639c8321843cff31c37bba8c