### PR TITLE
Fix course thumbnail URLs

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -63,7 +63,7 @@ class Course extends Model
     public function getThumbnailUrlAttribute(): string
     {
         if ($this->thumbnail && Storage::disk('public')->exists($this->thumbnail)) {
-            return Storage::url($this->thumbnail);
+            return Storage::disk('public')->url($this->thumbnail);
         }
 
         return asset('assets/default-course.jpg');

--- a/resources/views/admin/course_quiz/index.blade.php
+++ b/resources/views/admin/course_quiz/index.blade.php
@@ -28,7 +28,7 @@
                 @forelse($courses as $course)
                     <div class="item-card flex flex-col md:flex-row gap-y-10 justify-between md:items-center">
                         <div class="flex flex-row items-center gap-x-3">
-                            <img src="{{ Storage::url($course->thumbnail) }}" alt="{{ $course->name }}"
+                            <img src="{{ Storage::disk('public')->url($course->thumbnail) }}" alt="{{ $course->name }}"
                                 class="rounded-2xl object-cover w-[120px] h-[90px]">
                             <div class="flex flex-col">
                                 <h3 class="text-indigo-950 text-xl font-bold">{{ $course->name }}</h3>

--- a/resources/views/admin/course_videos/create.blade.php
+++ b/resources/views/admin/course_videos/create.blade.php
@@ -19,7 +19,7 @@
 
                 <div class="item-card flex flex-row gap-y-10 justify-between items-center">
                     <div class="flex flex-row items-center gap-x-3">
-                    <img src="{{Storage::url($course->thumbnail)}}" alt="" class="rounded-2xl object-cover w-[200px] h-[150px]">
+                    <img src="{{ Storage::disk('public')->url($course->thumbnail) }}" alt="" class="rounded-2xl object-cover w-[200px] h-[150px]">
                         <div class="flex flex-col">
                             <h3 class="text-indigo-950 text-xl font-bold">{{ $course->name }}</h3>
                             <p class="text-slate-500 text-sm">{{ $course->category->name }}</p>

--- a/resources/views/admin/course_videos/edit.blade.php
+++ b/resources/views/admin/course_videos/edit.blade.php
@@ -19,7 +19,7 @@
 
                 <div class="item-card flex flex-row gap-y-10 justify-between items-center">
                     <div class="flex flex-row items-center gap-x-3">
-                    <img src="{{Storage::url($courseVideo->course->thumbnail)}}" alt="" class="rounded-2xl object-cover w-[200px] h-[150px]">
+                    <img src="{{ Storage::disk('public')->url($courseVideo->course->thumbnail) }}" alt="" class="rounded-2xl object-cover w-[200px] h-[150px]">
                         <div class="flex flex-col">
                             <h3 class="text-indigo-950 text-xl font-bold">{{$courseVideo->course->name}}</h3>
                             <p class="text-slate-500 text-sm">{{$courseVideo->course->category->name}}</p>

--- a/resources/views/admin/courses/edit.blade.php
+++ b/resources/views/admin/courses/edit.blade.php
@@ -50,7 +50,7 @@
 
                     <div class="mt-4">
                         <x-input-label for="thumbnail" :value="__('Thumbnail')" />
-                        <img src="{{Storage::url($course->thumbnail)}}" alt="" class="rounded-2xl object-cover w-[120px] h-[90px]">
+                        <img src="{{ Storage::disk('public')->url($course->thumbnail) }}" alt="" class="rounded-2xl object-cover w-[120px] h-[90px]">
                         <x-text-input id="thumbnail" class="block mt-1 w-full" type="file" name="thumbnail" autocomplete="thumbnail" />
                         <x-input-error :messages="$errors->get('thumbnail')" class="mt-2" />
                     </div>

--- a/resources/views/admin/courses/index.blade.php
+++ b/resources/views/admin/courses/index.blade.php
@@ -17,7 +17,7 @@
             @forelse($courses as $course)
                 <div class="item-card flex flex-col md:flex-row gap-y-10 justify-between md:items-center">
                     <div class="flex flex-row items-center gap-x-3">
-                        <img src="{{Storage::url($course->thumbnail)}}" alt="" class="rounded-2xl object-cover w-[120px] h-[90px]">
+                        <img src="{{ Storage::disk('public')->url($course->thumbnail) }}" alt="" class="rounded-2xl object-cover w-[120px] h-[90px]">
                         <div class="flex flex-col">
                             <h3 class="text-indigo-950 text-xl font-bold">{{ $course->name }}</h3>
                             <p class="text-slate-500 text-sm">{{$course->category->name}}</p>

--- a/resources/views/admin/courses/show.blade.php
+++ b/resources/views/admin/courses/show.blade.php
@@ -12,7 +12,7 @@
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-10 flex flex-col gap-y-5">
                 <div class="item-card flex flex-row gap-y-10 justify-between items-center">
                     <div class="flex flex-row items-center gap-x-3">
-                        <img src="{{Storage::url($course->thumbnail)}}" alt="" class="rounded-2xl object-cover w-[200px] h-[150px]">
+                        <img src="{{ Storage::disk('public')->url($course->thumbnail) }}" alt="" class="rounded-2xl object-cover w-[200px] h-[150px]">
                         <div class="flex flex-col">
                             <h3 class="text-indigo-950 text-xl font-bold">{{$course->name}}</h3>
                             <p class="text-slate-500 text-sm">{{$course->category->name}}</p>


### PR DESCRIPTION
## Summary
- use public disk when generating course thumbnail URLs
- update admin templates to use Storage::disk('public') when showing thumbnails

## Testing
- `php artisan storage:link` *(fails: `php: command not found`)*
- `composer test` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684e622ecfcc8321b93747aa4a9d9b97