### PR TITLE
Implement curriculum item deletion

### DIFF
--- a/app/Http/Controllers/ModuleMaterialController.php
+++ b/app/Http/Controllers/ModuleMaterialController.php
@@ -39,4 +39,10 @@ class ModuleMaterialController extends Controller
         });
         return response()->json(['status' => 'ok']);
     }
+
+    public function destroy(CourseMaterial $courseMaterial)
+    {
+        $courseMaterial->delete();
+        return back();
+    }
 }

--- a/app/Http/Controllers/ModuleTaskController.php
+++ b/app/Http/Controllers/ModuleTaskController.php
@@ -36,4 +36,10 @@ class ModuleTaskController extends Controller
         });
         return response()->json(['status' => 'ok']);
     }
+
+    public function destroy(ModuleTask $moduleTask)
+    {
+        $moduleTask->delete();
+        return back();
+    }
 }

--- a/app/Http/Controllers/ModuleVideoController.php
+++ b/app/Http/Controllers/ModuleVideoController.php
@@ -37,4 +37,10 @@ class ModuleVideoController extends Controller
         });
         return response()->json(['status' => 'ok']);
     }
+
+    public function destroy(CourseVideo $courseVideo)
+    {
+        $courseVideo->delete();
+        return back();
+    }
 }

--- a/resources/views/admin/categories/index.blade.php
+++ b/resources/views/admin/categories/index.blade.php
@@ -30,7 +30,7 @@
             <a href="{{ route('admin.categories.edit', $category) }}" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">
                 Edit
             </a>
-            <form action="{{ route('admin.categories.destroy', $category) }}" method="POST">
+            <form action="{{ route('admin.categories.destroy', $category) }}" method="POST" onsubmit="return confirm('Are you sure?')">
                 @csrf
                 @method('DELETE')
                 <button type="submit" class="font-bold py-4 px-6 bg-red-700 text-white rounded-full">

--- a/resources/views/admin/courses/index.blade.php
+++ b/resources/views/admin/courses/index.blade.php
@@ -38,7 +38,7 @@
                         <a href="{{ route('admin.courses.show', $course)}}" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">
                             Manage
                         </a>
-                        <form action="{{ route('admin.courses.destroy', $course) }}" method="POST">
+                        <form action="{{ route('admin.courses.destroy', $course) }}" method="POST" onsubmit="return confirm('Are you sure?')">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="font-bold py-4 px-6 bg-red-700 text-white rounded-full">

--- a/resources/views/admin/courses/show.blade.php
+++ b/resources/views/admin/courses/show.blade.php
@@ -25,7 +25,7 @@
                         <a href="{{ route('admin.courses.edit', $course) }}" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">
                             Edit Course
                         </a>
-                        <form action="{{ route('admin.courses.destroy', $course) }}" method="POST">
+                        <form action="{{ route('admin.courses.destroy', $course) }}" method="POST" onsubmit="return confirm('Are you sure?')">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="font-bold py-4 px-6 bg-red-700 text-white rounded-full">
@@ -62,7 +62,7 @@
                         <a href="{{ route('admin.course_videos.edit', $video) }}" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">
                             Edit Video
                         </a>
-                        <form action="{{ route('admin.course_videos.destroy', $video) }}" method="POST">
+                        <form action="{{ route('admin.course_videos.destroy', $video) }}" method="POST" onsubmit="return confirm('Are you sure?')">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="font-bold py-4 px-6 bg-red-700 text-white rounded-full">

--- a/resources/views/admin/curriculum/index.blade.php
+++ b/resources/views/admin/curriculum/index.blade.php
@@ -25,7 +25,7 @@
                                 <input type="text" name="name" value="{{ $module->name }}" class="border rounded w-full">
                                 <button class="px-3 py-1 bg-indigo-700 text-white rounded">Save</button>
                             </form>
-                            <form method="POST" action="{{ route('admin.curriculum.destroy', $module) }}">
+                            <form method="POST" action="{{ route('admin.curriculum.destroy', $module) }}" onsubmit="return confirm('Are you sure?')">
                                 @csrf
                                 @method('DELETE')
                                 <button class="px-3 py-1 bg-red-700 text-white rounded">Delete</button>
@@ -43,19 +43,46 @@
                                 <h4 class="font-semibold">Videos</h4>
                                 <ul class="list-disc list-inside sortable-videos" data-module="{{ $module->id }}">
                                     @foreach($module->videos as $v)
-                                        <li class="video-item" data-id="{{ $v->id }}">{{ $v->name }}</li>
+                                        <li class="video-item" data-id="{{ $v->id }}">
+                                            <div class="flex justify-between items-center">
+                                                <span>{{ $v->name }}</span>
+                                                <form action="{{ route('admin.curriculum.videos.destroy', $v) }}" method="POST" onsubmit="return confirm('Are you sure?')">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600">Delete</button>
+                                                </form>
+                                            </div>
+                                        </li>
                                     @endforeach
                                 </ul>
                                 <h4 class="font-semibold mt-2">Materials</h4>
                                 <ul class="list-disc list-inside sortable-materials" data-module="{{ $module->id }}">
                                     @foreach($module->materials as $m)
-                                        <li class="material-item" data-id="{{ $m->id }}">{{ $m->name }}</li>
+                                        <li class="material-item" data-id="{{ $m->id }}">
+                                            <div class="flex justify-between items-center">
+                                                <span>{{ $m->name }}</span>
+                                                <form action="{{ route('admin.curriculum.materials.destroy', $m) }}" method="POST" onsubmit="return confirm('Are you sure?')">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600">Delete</button>
+                                                </form>
+                                            </div>
+                                        </li>
                                     @endforeach
                                 </ul>
                                 <h4 class="font-semibold mt-2">Tasks</h4>
                                 <ul class="list-disc list-inside sortable-tasks" data-module="{{ $module->id }}">
                                     @foreach($module->tasks as $t)
-                                        <li class="task-item" data-id="{{ $t->id }}">{{ $t->name }}</li>
+                                        <li class="task-item" data-id="{{ $t->id }}">
+                                            <div class="flex justify-between items-center">
+                                                <span>{{ $t->name }}</span>
+                                                <form action="{{ route('admin.curriculum.tasks.destroy', $t) }}" method="POST" onsubmit="return confirm('Are you sure?')">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="text-red-600">Delete</button>
+                                                </form>
+                                            </div>
+                                        </li>
                                     @endforeach
                                 </ul>
                             </div>

--- a/resources/views/admin/trainers/index.blade.php
+++ b/resources/views/admin/trainers/index.blade.php
@@ -29,7 +29,7 @@
                         <h3 class="text-indigo-950 text-xl font-bold">{{ $trainer->created_at }}</h3>
                     </div>
                     <div class="hidden md:flex flex-row items-center gap-x-3">
-                        <form action="{{ route('admin.trainers.destroy', $trainer) }}" method="POST">
+                        <form action="{{ route('admin.trainers.destroy', $trainer) }}" method="POST" onsubmit="return confirm('Are you sure?')">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="font-bold py-4 px-6 bg-red-700 text-white rounded-full">

--- a/routes/web.php
+++ b/routes/web.php
@@ -123,6 +123,9 @@ Route::middleware('auth')->group(function () {
                 Route::post('module/{courseModule}/videos', [ModuleVideoController::class, 'store'])->name('videos.store');
                 Route::post('module/{courseModule}/materials', [ModuleMaterialController::class, 'store'])->name('materials.store');
                 Route::post('module/{courseModule}/tasks', [ModuleTaskController::class, 'store'])->name('tasks.store');
+                Route::delete('videos/{courseVideo}', [ModuleVideoController::class, 'destroy'])->name('videos.destroy');
+                Route::delete('materials/{courseMaterial}', [ModuleMaterialController::class, 'destroy'])->name('materials.destroy');
+                Route::delete('tasks/{moduleTask}', [ModuleTaskController::class, 'destroy'])->name('tasks.destroy');
             });
 
           // Final Quiz Management Routes


### PR DESCRIPTION
## Summary
- add destroy methods for module videos, materials, and tasks
- register DELETE routes for curriculum items
- allow admin to delete videos, materials, and tasks from curriculum page
- add confirmation prompts on all admin delete forms

## Testing
- `phpunit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f440be3b48321916a62392d24643b