### PR TITLE
Add course enrollment window checks

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -117,6 +117,14 @@ class CourseController extends Controller
             return redirect()->route('front.pricing', $course->slug);
         }
 
+        if ($course->mode && $course->mode->name === 'onsite') {
+            $today = now()->toDateString();
+            if (($course->enrollment_start && $today < $course->enrollment_start) ||
+                ($course->enrollment_end && $today > $course->enrollment_end)) {
+                return redirect()->back()->with('error', 'Enrollment period is closed.');
+            }
+        }
+
         $existing = SubscribeTransaction::where('user_id', $user->id)
             ->where('course_id', $course->id)
             ->where('is_paid', true)

--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -254,9 +254,17 @@ class FrontController extends Controller
      * Proses penyimpanan data saat checkout
      */
 
-      public function checkout_store(StoreSubscribeTransactionRequest $request, Course $course)
+     public function checkout_store(StoreSubscribeTransactionRequest $request, Course $course)
      {
          $user = Auth::user();
+
+         if ($course->mode && $course->mode->name === 'onsite') {
+             $today = now()->toDateString();
+             if (($course->enrollment_start && $today < $course->enrollment_start) ||
+                 ($course->enrollment_end && $today > $course->enrollment_end)) {
+                 return redirect()->back()->with('error', 'Enrollment period is closed.');
+             }
+         }
      
          // Check if the user is already actively subscribed to THIS specific course
          if ($user->hasActiveSubscription($course)) {

--- a/app/Http/Controllers/SubscribeTransactionController.php
+++ b/app/Http/Controllers/SubscribeTransactionController.php
@@ -43,6 +43,14 @@ class SubscribeTransactionController extends Controller
         return redirect()->back()->with('error', 'Selected course not found.');
     }
 
+    if ($course->mode && $course->mode->name === 'onsite') {
+        $today = now()->toDateString();
+        if (($course->enrollment_start && $today < $course->enrollment_start) ||
+            ($course->enrollment_end && $today > $course->enrollment_end)) {
+            return redirect()->back()->with('error', 'Enrollment period is closed.');
+        }
+    }
+
     // Cek apakah user sudah pernah beli course ini dan sudah lunas
     $alreadyExists = SubscribeTransaction::where('user_id', $user->id)
                     ->where('course_id', $courseId)

--- a/app/Http/Requests/StoreCourseRequest.php
+++ b/app/Http/Requests/StoreCourseRequest.php
@@ -33,6 +33,8 @@ class StoreCourseRequest extends FormRequest
             'trainer_id' => 'nullable|exists:trainers,id',
             'course_keypoints.*' => 'nullable|string|max:255',
             'path_trailer' => 'required|string|max:255',
+            'enrollment_start' => 'nullable|date',
+            'enrollment_end' => 'nullable|date|after_or_equal:enrollment_start',
 
         ];
     }

--- a/app/Http/Requests/UpdateCourseRequest.php
+++ b/app/Http/Requests/UpdateCourseRequest.php
@@ -33,6 +33,8 @@ class UpdateCourseRequest extends FormRequest
             'price' => 'required|numeric|min:0',
             'trainer_id' => 'nullable|exists:trainers,id',
             'course_keypoints.*' => 'nullable|string|max:255',
+            'enrollment_start' => 'nullable|date',
+            'enrollment_end' => 'nullable|date|after_or_equal:enrollment_start',
         ];
     }
 }

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -23,7 +23,9 @@ class Course extends Model
         'category_id',
         'trainer_id',
         'course_mode_id',
-        'course_level_id'
+        'course_level_id',
+        'enrollment_start',
+        'enrollment_end'
     ];
 
     public function category(){

--- a/database/factories/CourseFactory.php
+++ b/database/factories/CourseFactory.php
@@ -21,6 +21,8 @@ class CourseFactory extends Factory
             'price' => 0,
             'course_mode_id' => null,
             'course_level_id' => null,
+            'enrollment_start' => null,
+            'enrollment_end' => null,
         ];
     }
 }

--- a/database/migrations/2025_08_05_100001_add_enrollment_dates_to_courses_table.php
+++ b/database/migrations/2025_08_05_100001_add_enrollment_dates_to_courses_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->date('enrollment_start')->nullable()->after('course_level_id');
+            $table->date('enrollment_end')->nullable()->after('enrollment_start');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->dropColumn(['enrollment_start', 'enrollment_end']);
+        });
+    }
+};

--- a/tests/Feature/EnrollmentWindowTest.php
+++ b/tests/Feature/EnrollmentWindowTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{Course, CourseMode, CourseLevel, User};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Carbon\Carbon;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class EnrollmentWindowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::firstOrCreate(['name' => 'trainee']);
+    }
+
+    public function test_join_outside_enrollment_dates_is_blocked(): void
+    {
+        Carbon::setTestNow('2025-01-01');
+
+        $mode = CourseMode::create(['name' => 'onsite']);
+        $level = CourseLevel::create(['name' => 'beginner']);
+
+        $course = Course::factory()->create([
+            'price' => 0,
+            'course_mode_id' => $mode->id,
+            'course_level_id' => $level->id,
+            'enrollment_start' => '2025-02-01',
+            'enrollment_end' => '2025-02-10',
+        ]);
+
+        $user = User::factory()->create();
+        $user->assignRole('trainee');
+
+        $response = $this->actingAs($user)->post(route('courses.join', $course->slug));
+        $response->assertSessionHas('error');
+
+        $this->assertDatabaseMissing('course_trainees', [
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+        ]);
+    }
+
+    public function test_checkout_outside_enrollment_dates_is_blocked(): void
+    {
+        Storage::fake('public');
+        Carbon::setTestNow('2025-01-01');
+
+        $mode = CourseMode::create(['name' => 'onsite']);
+        $level = CourseLevel::create(['name' => 'beginner']);
+
+        $course = Course::factory()->create([
+            'price' => 100,
+            'course_mode_id' => $mode->id,
+            'course_level_id' => $level->id,
+            'enrollment_start' => '2025-02-01',
+            'enrollment_end' => '2025-02-10',
+        ]);
+
+        $user = User::factory()->create();
+        $user->assignRole('trainee');
+
+        $response = $this->actingAs($user)->post(route('front.checkout.store', $course->slug), [
+            'course_id' => $course->id,
+            'proof' => UploadedFile::fake()->image('proof.jpg'),
+        ]);
+
+        $response->assertSessionHas('error');
+
+        $this->assertDatabaseMissing('subscribe_transactions', [
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow storing optional `enrollment_start` and `enrollment_end` dates for courses
- include the new fields in Course model and requests
- prevent joining or purchasing onsite courses outside of enrollment window
- create feature tests for the enrollment restriction

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f45dd4ac8832186246cd8cf85e290