### PR TITLE
Add meeting management link

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -233,6 +233,7 @@ public function store(StoreCourseRequest $request)
         'modules.videos',
         'modules.materials',
         'modules.tasks',
+        'meetings',
     ]);
 
     return view('admin.courses.show', compact('course'));

--- a/app/Http/Controllers/CourseMeetingController.php
+++ b/app/Http/Controllers/CourseMeetingController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Course;
+use App\Models\CourseMeeting;
+use Illuminate\Http\Request;
+
+class CourseMeetingController extends Controller
+{
+    public function index(Course $course)
+    {
+        $course->load('meetings');
+        return view('admin.meetings.index', compact('course'));
+    }
+
+    public function create(Course $course)
+    {
+        return view('admin.meetings.create', compact('course'));
+    }
+
+    public function store(Request $request, Course $course)
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'start_datetime' => 'required|date',
+            'end_datetime' => 'required|date|after:start_datetime',
+            'location' => 'nullable|string|max:255',
+        ]);
+        $course->meetings()->create($data);
+        return redirect()->route('admin.courses.meetings.index', $course);
+    }
+
+    public function edit(Course $course, CourseMeeting $meeting)
+    {
+        return view('admin.meetings.edit', compact('course', 'meeting'));
+    }
+
+    public function update(Request $request, Course $course, CourseMeeting $meeting)
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'start_datetime' => 'required|date',
+            'end_datetime' => 'required|date|after:start_datetime',
+            'location' => 'nullable|string|max:255',
+        ]);
+        $meeting->update($data);
+        return redirect()->route('admin.courses.meetings.index', $course);
+    }
+
+    public function destroy(Course $course, CourseMeeting $meeting)
+    {
+        $meeting->delete();
+        return redirect()->route('admin.courses.meetings.index', $course);
+    }
+}

--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -85,6 +85,7 @@ class FrontController extends Controller
             "course_videos", "course_keypoints",
             "modules.videos", "modules.materials", "modules.tasks",
             "finalQuiz",
+            "meetings",
         ]);
 
         $user = Auth::user();

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\Certificate;
 use App\Models\CourseModule;
+use App\Models\CourseMeeting;
 use Illuminate\Support\Facades\Storage;
 
 class Course extends Model
@@ -94,6 +95,11 @@ public function finalQuizzes()
     public function certificates()
     {
         return $this->hasMany(Certificate::class);
+    }
+
+    public function meetings()
+    {
+        return $this->hasMany(CourseMeeting::class);
     }
 
 

--- a/app/Models/CourseMeeting.php
+++ b/app/Models/CourseMeeting.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CourseMeeting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'course_id',
+        'title',
+        'start_datetime',
+        'end_datetime',
+        'location',
+    ];
+
+    protected $casts = [
+        'start_datetime' => 'datetime',
+        'end_datetime' => 'datetime',
+    ];
+
+    public function course()
+    {
+        return $this->belongsTo(Course::class);
+    }
+}

--- a/database/migrations/2025_08_06_000000_create_course_meetings_table.php
+++ b/database/migrations/2025_08_06_000000_create_course_meetings_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('course_meetings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained()->onDelete('cascade');
+            $table->string('title');
+            $table->dateTime('start_datetime');
+            $table->dateTime('end_datetime');
+            $table->string('location')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('course_meetings');
+    }
+};

--- a/database/seeders/CourseMeetingSeeder.php
+++ b/database/seeders/CourseMeetingSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Course;
+use App\Models\CourseMeeting;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class CourseMeetingSeeder extends Seeder
+{
+    public function run(): void
+    {
+        foreach (Course::take(2)->get() as $course) {
+            CourseMeeting::firstOrCreate([
+                'course_id' => $course->id,
+                'title' => 'Kickoff Meeting',
+            ], [
+                'start_datetime' => Carbon::now()->addDays(1),
+                'end_datetime' => Carbon::now()->addDays(1)->addHours(2),
+                'location' => 'Room 101',
+            ]);
+
+            CourseMeeting::firstOrCreate([
+                'course_id' => $course->id,
+                'title' => 'Second Session',
+            ], [
+                'start_datetime' => Carbon::now()->addDays(3),
+                'end_datetime' => Carbon::now()->addDays(3)->addHours(2),
+                'location' => 'Room 102',
+            ]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -36,6 +36,8 @@ class DatabaseSeeder extends Seeder
         $this->command->info('🎓 Creating trainee with LMS completion data...');
         $this->call(TraineeSeeder::class);
 
+        $this->call(CourseMeetingSeeder::class);
+
         $this->command->info('✅ Seeding completed successfully!');
         $this->displaySystemSummary();
     }

--- a/resources/views/admin/courses/show.blade.php
+++ b/resources/views/admin/courses/show.blade.php
@@ -119,6 +119,28 @@
                         </div>
                     </div>
                 @endforeach
+
+                <hr class="my-5">
+
+                <div class="flex flex-row justify-between items-center mb-4">
+                    <div class="flex flex-col">
+                        <h3 class="text-indigo-950 text-xl font-bold">Meetings</h3>
+                        <p class="text-slate-500 text-sm">{{ $course->meetings->count() }}</p>
+                    </div>
+                    <a href="{{ route('admin.courses.meetings.index', $course) }}" class="font-bold py-4 px-6 bg-indigo-700 text-white rounded-full">Manage Meetings</a>
+                </div>
+
+                @foreach($course->meetings as $meeting)
+                    <div class="border rounded p-4 mb-3 flex justify-between items-center">
+                        <div>
+                            <h4 class="font-semibold">{{ $meeting->title }}</h4>
+                            <p class="text-sm text-gray-600">{{ $meeting->start_datetime->format('d M Y H:i') }} - {{ $meeting->end_datetime->format('d M Y H:i') }}</p>
+                            @if($meeting->location)
+                                <p class="text-sm text-gray-600">{{ $meeting->location }}</p>
+                            @endif
+                        </div>
+                    </div>
+                @endforeach
                 
             </div>
         </div>

--- a/resources/views/admin/meetings/create.blade.php
+++ b/resources/views/admin/meetings/create.blade.php
@@ -1,0 +1,32 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">Add Meeting - {{ $course->name }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('admin.courses.meetings.store', $course) }}">
+                    @csrf
+                    <div class="mb-4">
+                        <label class="block text-gray-700">Title</label>
+                        <input type="text" name="title" class="w-full border rounded" required>
+                    </div>
+                    <div class="mb-4">
+                        <label class="block text-gray-700">Start</label>
+                        <input type="datetime-local" name="start_datetime" class="w-full border rounded" required>
+                    </div>
+                    <div class="mb-4">
+                        <label class="block text-gray-700">End</label>
+                        <input type="datetime-local" name="end_datetime" class="w-full border rounded" required>
+                    </div>
+                    <div class="mb-4">
+                        <label class="block text-gray-700">Location</label>
+                        <input type="text" name="location" class="w-full border rounded">
+                    </div>
+                    <button type="submit" class="py-2 px-4 bg-indigo-700 text-white rounded">Save</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/meetings/edit.blade.php
+++ b/resources/views/admin/meetings/edit.blade.php
@@ -1,0 +1,33 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">Edit Meeting - {{ $course->name }}</h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('admin.courses.meetings.update', [$course, $meeting]) }}">
+                    @csrf
+                    @method('PUT')
+                    <div class="mb-4">
+                        <label class="block text-gray-700">Title</label>
+                        <input type="text" name="title" class="w-full border rounded" value="{{ $meeting->title }}" required>
+                    </div>
+                    <div class="mb-4">
+                        <label class="block text-gray-700">Start</label>
+                        <input type="datetime-local" name="start_datetime" class="w-full border rounded" value="{{ $meeting->start_datetime->format('Y-m-d\TH:i') }}" required>
+                    </div>
+                    <div class="mb-4">
+                        <label class="block text-gray-700">End</label>
+                        <input type="datetime-local" name="end_datetime" class="w-full border rounded" value="{{ $meeting->end_datetime->format('Y-m-d\TH:i') }}" required>
+                    </div>
+                    <div class="mb-4">
+                        <label class="block text-gray-700">Location</label>
+                        <input type="text" name="location" class="w-full border rounded" value="{{ $meeting->location }}">
+                    </div>
+                    <button type="submit" class="py-2 px-4 bg-indigo-700 text-white rounded">Update</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/meetings/index.blade.php
+++ b/resources/views/admin/meetings/index.blade.php
@@ -1,0 +1,38 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+                {{ __('Manage Meetings') }} - {{ $course->name }}
+            </h2>
+            <a href="{{ route('admin.courses.meetings.create', $course) }}" class="font-bold py-2 px-4 bg-indigo-700 text-white rounded-full">Add Meeting</a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                @forelse($course->meetings as $meeting)
+                    <div class="border-b py-4 flex justify-between items-center">
+                        <div>
+                            <h3 class="font-semibold">{{ $meeting->title }}</h3>
+                            <p class="text-sm text-gray-600">{{ $meeting->start_datetime }} - {{ $meeting->end_datetime }}</p>
+                            @if($meeting->location)
+                                <p class="text-sm text-gray-600">{{ $meeting->location }}</p>
+                            @endif
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <a href="{{ route('admin.courses.meetings.edit', [$course, $meeting]) }}" class="py-1 px-3 bg-yellow-500 text-white rounded">Edit</a>
+                            <form action="{{ route('admin.courses.meetings.destroy', [$course, $meeting]) }}" method="POST" onsubmit="return confirm('Are you sure?')">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="py-1 px-3 bg-red-600 text-white rounded">Delete</button>
+                            </form>
+                        </div>
+                    </div>
+                @empty
+                    <p>No meetings scheduled.</p>
+                @endforelse
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/front/learning.blade.php
+++ b/resources/views/front/learning.blade.php
@@ -167,6 +167,32 @@
                                     </div>
                                     @endforeach
                                 </div>
+
+                                @if($course->mode && strtolower($course->mode->name) === 'onsite')
+                                    <div class="mt-6">
+                                        <h4 class="font-semibold text-xl mb-2">Schedule</h4>
+                                        <table class="w-full text-left border">
+                                            <thead>
+                                                <tr>
+                                                    <th class="p-2 border">Title</th>
+                                                    <th class="p-2 border">Start</th>
+                                                    <th class="p-2 border">End</th>
+                                                    <th class="p-2 border">Location</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                @foreach($course->meetings as $meeting)
+                                                <tr>
+                                                    <td class="p-2 border">{{ $meeting->title }}</td>
+                                                    <td class="p-2 border">{{ $meeting->start_datetime->format('d M Y H:i') }}</td>
+                                                    <td class="p-2 border">{{ $meeting->end_datetime->format('d M Y H:i') }}</td>
+                                                    <td class="p-2 border">{{ $meeting->location ?? '-' }}</td>
+                                                </tr>
+                                                @endforeach
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                @endif
                             </div>
                         </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\{
     SubscribeTransactionController,
     TrainerController,
     FinalQuizController,
+    CourseMeetingController,
     QuizAttemptController, // Pastikan ini sudah ada
     CertificateController,
     TalentAdminController,
@@ -103,6 +104,7 @@ Route::middleware('auth')->group(function () {
             Route::resource('courses', CourseController::class);
             Route::resource('course_videos', CourseVideoController::class);
             Route::resource('course_modules', CourseModuleController::class);
+            Route::resource('courses.meetings', CourseMeetingController::class)->except('show');
 
             Route::get('/add/video/{course:id}', [CourseVideoController::class, 'create'])->name('course.add_video');
             Route::post('/add/video/save/{course:id}', [CourseVideoController::class, 'store'])->name('course.add_video.save');

--- a/tests/Feature/MeetingDisplayTest.php
+++ b/tests/Feature/MeetingDisplayTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{User, Course, CourseVideo, CourseMode, CourseMeeting, SubscribeTransaction};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class MeetingDisplayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::firstOrCreate(['name' => 'trainee']);
+    }
+
+    public function test_meeting_times_display_on_learning_page(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('trainee');
+
+        $mode = CourseMode::create(['name' => 'onsite']);
+        $course = Course::factory()->create(['course_mode_id' => $mode->id]);
+        $video = CourseVideo::factory()->create(['course_id' => $course->id]);
+
+        $meeting = CourseMeeting::create([
+            'course_id' => $course->id,
+            'title' => 'Session 1',
+            'start_datetime' => Carbon::now()->addDay(),
+            'end_datetime' => Carbon::now()->addDay()->addHour(),
+            'location' => 'Lab 1',
+        ]);
+
+        SubscribeTransaction::create([
+            'total_amount' => 0,
+            'is_paid' => true,
+            'user_id' => $user->id,
+            'course_id' => $course->id,
+            'proof' => 'proof.png',
+            'subscription_start_date' => now(),
+        ]);
+
+        $response = $this->actingAs($user)->get(route('front.learning', [$course->id, $video->id]));
+
+        $response->assertStatus(200);
+        $response->assertSee($meeting->title);
+        $response->assertSee($meeting->start_datetime->format('d M Y H:i'));
+    }
+}


### PR DESCRIPTION
## Summary
- load meetings in course details controller
- show meetings section on course management page

## Testing
- `php artisan test --filter=MeetingDisplayTest` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f45e622a88321abdd15858e20f099