### PR TITLE
Add enrollment period support

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -180,6 +180,9 @@ public function store(StoreCourseRequest $request)
 {
     $data = $request->validated();
 
+    $data['enrollment_start'] = $request->input('enrollment_start');
+    $data['enrollment_end'] = $request->input('enrollment_end');
+
     // Upload thumbnail
     if ($request->hasFile('thumbnail')) {
         $path = $request->file('thumbnail')->store('thumbnails', 'public');
@@ -271,6 +274,9 @@ public function store(StoreCourseRequest $request)
     {
         DB::transaction(function () use ($request, $course) {
             $validated = $request->validated();
+
+            $validated['enrollment_start'] = $request->input('enrollment_start');
+            $validated['enrollment_end'] = $request->input('enrollment_end');
 
             if (Auth::user()->hasRole('admin') && $request->filled('trainer_id')) {
                 $course->trainer_id = $request->input('trainer_id');

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -29,6 +29,11 @@ class Course extends Model
         'enrollment_end'
     ];
 
+    protected $casts = [
+        'enrollment_start' => 'datetime',
+        'enrollment_end' => 'datetime',
+    ];
+
     public function category(){
         return $this->belongsTo(Category::class);
 

--- a/database/factories/CourseFactory.php
+++ b/database/factories/CourseFactory.php
@@ -10,6 +10,9 @@ class CourseFactory extends Factory
 
     public function definition(): array
     {
+        $start = $this->faker->dateTimeBetween('-1 month', '+1 month');
+        $end = (clone $start)->modify('+'.$this->faker->numberBetween(5, 30).' days');
+
         return [
             'name' => $this->faker->sentence(3),
             'slug' => $this->faker->unique()->slug(),
@@ -21,8 +24,8 @@ class CourseFactory extends Factory
             'price' => 0,
             'course_mode_id' => null,
             'course_level_id' => null,
-            'enrollment_start' => null,
-            'enrollment_end' => null,
+            'enrollment_start' => $start,
+            'enrollment_end' => $end,
         ];
     }
 }

--- a/database/migrations/2025_08_07_000002_add_enrollment_period_to_courses_table.php
+++ b/database/migrations/2025_08_07_000002_add_enrollment_period_to_courses_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->dateTime('enrollment_start')->nullable()->change();
+            $table->dateTime('enrollment_end')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->date('enrollment_start')->nullable()->change();
+            $table->date('enrollment_end')->nullable()->change();
+        });
+    }
+};

--- a/database/seeders/TraineeSeeder.php
+++ b/database/seeders/TraineeSeeder.php
@@ -235,6 +235,8 @@ class TraineeSeeder extends Seeder
                 'thumbnail' => '/images/courses/' . $courseData['slug'] . '.jpg',
                 'trainer_id' => $defaultTrainer->id,
                 'created_at' => $faker->dateTimeBetween('-1 year', '-6 months'),
+                'enrollment_start' => now()->subWeeks(1),
+                'enrollment_end' => now()->addWeeks(3),
             ];
 
             // Add course_mode_id if it exists

--- a/resources/views/admin/courses/create.blade.php
+++ b/resources/views/admin/courses/create.blade.php
@@ -96,6 +96,18 @@
                     </div>
 
                     <div class="mt-4">
+                        <x-input-label for="enrollment_start" :value="__('Enrollment Start')" />
+                        <x-text-input id="enrollment_start" class="block mt-1 w-full" type="datetime-local" name="enrollment_start" :value="old('enrollment_start')" />
+                        <x-input-error :messages="$errors->get('enrollment_start')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-input-label for="enrollment_end" :value="__('Enrollment End')" />
+                        <x-text-input id="enrollment_end" class="block mt-1 w-full" type="datetime-local" name="enrollment_end" :value="old('enrollment_end')" />
+                        <x-input-error :messages="$errors->get('enrollment_end')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
                         <x-input-label for="about" :value="__('about')" />
                         <textarea name="about" id="about" cols="30" rows="5" class="border border-slate-300 rounded-xl w-full"></textarea>
                         <x-input-error :messages="$errors->get('about')" class="mt-2" />

--- a/resources/views/admin/courses/edit.blade.php
+++ b/resources/views/admin/courses/edit.blade.php
@@ -99,6 +99,18 @@
                     </div>
 
                     <div class="mt-4">
+                        <x-input-label for="enrollment_start" :value="__('Enrollment Start')" />
+                        <x-text-input id="enrollment_start" class="block mt-1 w-full" type="datetime-local" name="enrollment_start" :value="old('enrollment_start', optional($course->enrollment_start)->format('Y-m-d\TH:i'))" />
+                        <x-input-error :messages="$errors->get('enrollment_start')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-input-label for="enrollment_end" :value="__('Enrollment End')" />
+                        <x-text-input id="enrollment_end" class="block mt-1 w-full" type="datetime-local" name="enrollment_end" :value="old('enrollment_end', optional($course->enrollment_end)->format('Y-m-d\TH:i'))" />
+                        <x-input-error :messages="$errors->get('enrollment_end')" class="mt-2" />
+                    </div>
+
+                    <div class="mt-4">
                         <x-input-label for="about" :value="__('About')" />
                         <textarea name="about" id="about" cols="30" rows="5" class="border border-slate-300 rounded-xl w-full">{{ $course->about }}</textarea>
                         <x-input-error :messages="$errors->get('about')" class="mt-2" />

--- a/resources/views/admin/courses/show.blade.php
+++ b/resources/views/admin/courses/show.blade.php
@@ -36,6 +36,17 @@
                     </div>
                 </div>
 
+                @if($course->enrollment_start || $course->enrollment_end)
+                    <div>
+                        <p class="text-slate-500 text-sm">Enrollment Period</p>
+                        <p class="text-indigo-950 text-md font-semibold">
+                            {{ $course->enrollment_start ? $course->enrollment_start->format('d M Y H:i') : '-' }}
+                            -
+                            {{ $course->enrollment_end ? $course->enrollment_end->format('d M Y H:i') : '-' }}
+                        </p>
+                    </div>
+                @endif
+
                 <hr class="my-5">
 
                 <div class="flex flex-row justify-between items-center">


### PR DESCRIPTION
## Summary
- add migration changing enrollment columns to datetime
- cast enrollment columns to datetime on `Course` model
- persist enrollment dates in `CourseController`
- add enrollment fields to create/edit forms and show details
- populate enrollment dates in factory and seeder

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f584175d0832198815e7563508b9f