### PR TITLE
Display enrollment dates in course lists

### DIFF
--- a/resources/views/front/explore.blade.php
+++ b/resources/views/front/explore.blade.php
@@ -90,6 +90,14 @@
                             <a href="{{ route('front.details', $course->slug) }}" class="font-semibold text-lg line-clamp-2 hover:underline">{{ $course->name }}</a>
                             <p class="text-sm text-gray-600">Trainer: {{ $course->trainer?->user?->name ?? 'Unknown' }}</p>
                             <p class="text-sm text-gray-600">{{ $course->mode->name ?? '' }} - {{ $course->level->name ?? '' }}</p>
+                            @if($course->enrollment_start || $course->enrollment_end)
+                                <p class="text-xs text-gray-500">
+                                    Enrollment:
+                                    {{ $course->enrollment_start ? $course->enrollment_start->format('d M Y') : '-' }}
+                                    -
+                                    {{ $course->enrollment_end ? $course->enrollment_end->format('d M Y') : '-' }}
+                                </p>
+                            @endif
                             <p class="font-semibold">{{ $course->price > 0 ? 'Rp ' . number_format($course->price, 0, ',', '.') : 'FREE' }}</p>
                             <a href="{{ route('front.details', $course->slug) }}" class="mt-2 inline-block bg-[#FF6129] text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-[#e85520] transition-all">Lihat Detail</a>
                         </div>

--- a/resources/views/front/index.blade.php
+++ b/resources/views/front/index.blade.php
@@ -141,6 +141,14 @@
                                     {{ $course->price > 0 ? 'Rp ' . number_format($course->price, 0, ',', '.') : 'FREE' }}
                                 </div>
                                 <p class="text-sm text-[#6D7786]">{{ $course->mode->name ?? '' }} - {{ $course->level->name ?? '' }}</p>
+                                @if($course->enrollment_start || $course->enrollment_end)
+                                <p class="text-xs text-gray-500">
+                                    Enrollment:
+                                    {{ $course->enrollment_start ? $course->enrollment_start->format('d M Y') : '-' }}
+                                    -
+                                    {{ $course->enrollment_end ? $course->enrollment_end->format('d M Y') : '-' }}
+                                </p>
+                                @endif
 
                                 <form action="{{ route('cart.store', $course->slug) }}" method="POST">
                                     @csrf

--- a/resources/views/partials/course-list.blade.php
+++ b/resources/views/partials/course-list.blade.php
@@ -11,6 +11,14 @@
                     {{ $course->price > 0 ? 'Rp ' . number_format($course->price, 0, ',', '.') : 'FREE' }}
                 </div>
                 <p class="text-sm text-[#6D7786]">{{ $course->mode->name ?? '' }} - {{ $course->level->name ?? '' }}</p>
+                @if($course->enrollment_start || $course->enrollment_end)
+                <p class="text-xs text-gray-500">
+                    Enrollment:
+                    {{ $course->enrollment_start ? $course->enrollment_start->format('d M Y') : '-' }}
+                    -
+                    {{ $course->enrollment_end ? $course->enrollment_end->format('d M Y') : '-' }}
+                </p>
+                @endif
 
                 <form action="{{ route('cart.store', $course->slug) }}" method="POST">
                     @csrf


### PR DESCRIPTION
## Summary
- show enrollment period on the home page course list
- show enrollment period on the explore page
- show enrollment period on AJAX course list

## Testing
- `php artisan test --testsuite=Feature` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f6768f0108321a956ebc5ba957b2d