### PR TITLE
Fix trainee seeder certificate paths

### DIFF
--- a/database/seeders/TraineeSeeder.php
+++ b/database/seeders/TraineeSeeder.php
@@ -12,6 +12,7 @@ use App\Models\Certificate;
 use App\Models\Trainer;
 use App\Models\FinalQuiz;
 use App\Models\QuizAttempt;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Database\Seeder;
 use Faker\Factory as Faker;
 
@@ -87,11 +88,14 @@ class TraineeSeeder extends Seeder
                 'quiz_passed' => true,
                 'progress' => 100.0,
             ]);            // Generate certificate
+            $path = 'certificates/' . $traineeUser->id . '_' . $course->id . '.pdf';
+            Storage::disk('public')->put($path, '');
+
             Certificate::firstOrCreate([
                 'user_id' => $traineeUser->id,
                 'course_id' => $course->id,
             ], [
-                'path' => '/certificates/' . $traineeUser->id . '/' . $course->id . '.pdf',
+                'path' => $path,
                 'generated_at' => $faker->dateTimeBetween('-3 months', '-1 month'),
             ]);
 


### PR DESCRIPTION
## Summary
- align certificate path format in `TraineeSeeder`
- create placeholder certificate files so file_size can be read
- import `Storage` facade

## Testing
- `php -v` *(fails: command not found)*
- `php artisan db:seed` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5776cde48321821ec27feb3420f7