### PR TITLE
Update responsive course grid layout

### DIFF
--- a/resources/views/front/explore.blade.php
+++ b/resources/views/front/explore.blade.php
@@ -81,7 +81,7 @@
 
             <!-- Course List -->
             <div class="flex-1">
-                <div id="courseContent" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+                <div id="courseContent" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                     @foreach($courses as $course)
                     <div class="flex flex-col rounded-xl bg-white overflow-hidden transition-all hover:ring-2 hover:ring-[#FF6129]">
                         <a href="{{ route('front.details', $course->slug) }}" class="thumbnail w-full h-[200px] shrink-0 rounded-[10px] overflow-hidden">

--- a/resources/views/front/index.blade.php
+++ b/resources/views/front/index.blade.php
@@ -128,7 +128,7 @@
             </button>
             <div id="course-slider" class="w-full">
 
-            <div id="courseContent" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-10">
+            <div id="courseContent" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-10">
                     @forelse($courses as $course)
                     <div class="course-card px-3 pb-[70px] mt-[2px]">
                         <div class="flex flex-col rounded-t-[12px] rounded-b-[24px] gap-[32px] bg-white w-full pb-[10px] overflow-hidden transition-all duration-300 hover:ring-2 hover:ring-[#FF6129]">

--- a/resources/views/front/my_courses.blade.php
+++ b/resources/views/front/my_courses.blade.php
@@ -57,7 +57,7 @@
 
         <!-- Konten -->
         <div class="px-[50px]" id="courseContent">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                 @foreach($courses as $course)
 @php $firstVideo = $course->course_videos->first(); @endphp
                 <div class="flex flex-col rounded-xl bg-white overflow-hidden transition-all hover:ring-2 hover:ring-[#FF6129]">

--- a/resources/views/partials/course-list.blade.php
+++ b/resources/views/partials/course-list.blade.php
@@ -1,6 +1,6 @@
 <div class="flex flex-wrap" id="ajax-course-wrapper">
     @forelse($courses as $course)
-    <div class="course-card w-1/3 px-3 pb-[70px] mt-[2px]">
+    <div class="course-card w-full sm:w-1/2 lg:w-1/3 xl:w-1/4 px-3 pb-[70px] mt-[2px]">
         <div class="flex flex-col rounded-t-[12px] rounded-b-[24px] gap-[32px] bg-white w-full pb-[10px] overflow-hidden transition-all duration-300 hover:ring-2 hover:ring-[#FF6129]">
             <a href="{{ route('front.details', $course->slug) }}" class="thumbnail w-full h-[200px] shrink-0 rounded-[10px] overflow-hidden">
             <img src="{{ asset(path: 'storage/' . $course->thumbnail) }}" class="rounded-2xl object-cover w-[120px] h-[90px]" alt="thumbnail">


### PR DESCRIPTION
## Summary
- adjust grid breakpoints to show up to four cards in a row
- make course card widths responsive for more columns

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e80d84d48321925376bde32ab2b4